### PR TITLE
Implement RankerService using OpenAI

### DIFF
--- a/server/app/services/ranker.py
+++ b/server/app/services/ranker.py
@@ -1,0 +1,49 @@
+import json
+import os
+from typing import Any, Dict, List
+
+import openai
+
+
+class RankerService:
+    """Service for generating rankings using OpenAI."""
+
+    model = "gpt-4o"
+    temperature = 0
+
+    def __init__(self) -> None:
+        openai.api_key = os.environ.get("OPENAI_API_KEY")
+
+    def _call_openai(self, prompt: str) -> List[Dict[str, Any]]:
+        """Call OpenAI API and return parsed JSON response.
+
+        Retries once on JSON parse error.
+        """
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Strictly return a pure JSON array where each element has "
+                    "the fields: name, score, rank, and reasons mapping criterion to reason."
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ]
+
+        for _ in range(2):
+            response = openai.ChatCompletion.create(
+                model=self.model,
+                temperature=self.temperature,
+                messages=messages,
+            )
+            content = response.choices[0].message["content"]
+            try:
+                return json.loads(content)
+            except json.JSONDecodeError:
+                # Retry once
+                continue
+        raise ValueError("Failed to parse JSON from OpenAI response")
+
+    def rank(self, prompt: str) -> List[Dict[str, Any]]:
+        """Public method to generate ranking from a prompt."""
+        return self._call_openai(prompt)


### PR DESCRIPTION
## Summary
- add `RankerService` with `gpt-4o` call
- ensure pure JSON array return
- retry once on JSON parsing failure

## Testing
- `python -m py_compile server/app/services/ranker.py`

------
https://chatgpt.com/codex/tasks/task_e_6841bb78241c8323a62e2605c7fe0574