### PR TITLE
Add dummy history features

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,14 +1,22 @@
 from fastapi import FastAPI
 from .services.ranker import RankerService
+from typing import Any, List
 
 app = FastAPI()
 ranker = RankerService()
+history_store: List[Any] = []
 
 @app.post("/rank")
 async def rank(prompt: str):
     return ranker.rank(prompt)
 
+@app.post("/history")
+async def save_history(data: Any):
+    """Store ranking results in-memory."""
+    history_store.append(data)
+    return {"status": "ok"}
+
 @app.get("/history")
 async def history():
-    """Placeholder for future user history."""
-    return []
+    """Retrieve saved history."""
+    return history_store

--- a/web/components/SaveHistoryButton.tsx
+++ b/web/components/SaveHistoryButton.tsx
@@ -1,0 +1,24 @@
+import { useTranslations } from 'next-intl';
+
+export default function SaveHistoryButton({ data }: { data: any }) {
+  const t = useTranslations();
+
+  const handleSave = async () => {
+    try {
+      await fetch('http://localhost:8000/history', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
+      });
+      alert('Saved!');
+    } catch (err) {
+      alert('Failed to save');
+    }
+  };
+
+  return (
+    <button onClick={handleSave}>{t('saveHistory')}</button>
+  );
+}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -3,4 +3,5 @@
   "exportPdf": "Export PDF",
   "exportCsv": "Export CSV",
   "language": "Language"
+  ,"saveHistory": "Save to history"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -3,4 +3,5 @@
   "exportPdf": "PDFをエクスポート",
   "exportCsv": "CSVをエクスポート",
   "language": "言語"
+  ,"saveHistory": "履歴に保存"
 }

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -1,5 +1,6 @@
 import LanguageSwitcher from '../components/LanguageSwitcher';
 import ExportButtons from '../components/ExportButtons';
+import SaveHistoryButton from '../components/SaveHistoryButton';
 import { useTranslations } from 'next-intl';
 
 export default function Results() {
@@ -20,6 +21,7 @@ export default function Results() {
         ))}
       </ul>
       <ExportButtons />
+      <SaveHistoryButton data={dummyResults} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement in-memory `/history` API for saving rankings
- add SaveHistoryButton component
- wire up history button on results page
- localize text for new button

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e74ee4488323a4bdbfda2672e367