### PR TITLE
Add deployment configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your-openai-api-key
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 # Python
 __pycache__
 *.pyc
+.env
 
 # Misc
 .DS_Store

--- a/HOW_TO_DEPLOY.md
+++ b/HOW_TO_DEPLOY.md
@@ -1,0 +1,14 @@
+# How to Deploy
+
+This repository contains a Next.js frontend in `web` and a FastAPI backend in `server`.
+
+## Deploy the frontend to Vercel
+1. Create a new project in Vercel and select this repository.
+2. When prompted for the project directory, choose `web`.
+3. Set the environment variable `NEXT_PUBLIC_API_URL` to the public URL of the Render service (see below).
+4. Deploy.
+
+## Deploy the backend to Render
+1. Create a new Web Service in Render from this repository. Render will automatically read `Render.yaml`.
+2. Provide the environment variable `OPENAI_API_KEY`.
+3. Deploy the service. Once live, note the service URL and use it for `NEXT_PUBLIC_API_URL` in Vercel.

--- a/Render.yaml
+++ b/Render.yaml
@@ -1,0 +1,10 @@
+services:
+  - type: web
+    name: ranking-api
+    env: python
+    plan: free
+    rootDir: server
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    envVars:
+      - key: OPENAI_API_KEY

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "builds": [
+    { "src": "web/package.json", "use": "@vercel/next" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "web/$1" }
+  ]
+}

--- a/web/components/SaveHistoryButton.tsx
+++ b/web/components/SaveHistoryButton.tsx
@@ -3,9 +3,11 @@ import { useTranslations } from 'next-intl';
 export default function SaveHistoryButton({ data }: { data: any }) {
   const t = useTranslations();
 
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
   const handleSave = async () => {
     try {
-      await fetch('http://localhost:8000/history', {
+      await fetch(`${apiUrl}/history`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- add deployment configuration for Vercel and Render
- support API base URL via env var in SaveHistoryButton
- document how to deploy
- provide example environment variables
- ignore local `.env` files

## Testing
- `python3 -m py_compile server/app/*.py`
- `python3 -m py_compile server/app/services/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6843508349748323b1ac053b9103f858