### PR TITLE
Fix NextIntl timezone config

### DIFF
--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -6,8 +6,11 @@ import '../styles.css';
 export default function MyApp({ Component, pageProps }: AppProps) {
   const { locale } = useRouter();
   const messages = require(`../messages/${locale}.json`);
+  // Set a global default time zone to avoid server/client mismatches
+  // See https://next-intl.dev/docs/configuration#time-zone
+  const timeZone = process.env.NEXT_PUBLIC_TIME_ZONE || 'UTC';
   return (
-    <NextIntlClientProvider locale={locale!} messages={messages}>
+    <NextIntlClientProvider locale={locale!} messages={messages} timeZone={timeZone}>
       <Component {...pageProps} />
     </NextIntlClientProvider>
   );


### PR DESCRIPTION
## Summary
- set a default time zone in `_app.tsx` to avoid ENVIRONMENT_FALLBACK errors

## Testing
- `npm run build`
- `npm run dev` (terminated after start)


------
https://chatgpt.com/codex/tasks/task_e_6843f00766ac83239f5ba20ef01e11c5