### PR TITLE
Improve ranking UI with Tailwind

### DIFF
--- a/web/components/ExportButtons.tsx
+++ b/web/components/ExportButtons.tsx
@@ -7,8 +7,19 @@ export default function ExportButtons() {
   };
   return (
     <div className="buttons">
-      <button onClick={() => handleClick('PDF')}>{t('exportPdf')}</button>
-      <button onClick={() => handleClick('CSV')}>{t('exportCsv')}</button>
+      <button
+        className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+        onClick={() => handleClick('PDF')}
+      >
+        {t('exportPdf')}
+      </button>
+      <button
+        className="px-3 py-1 bg-green-600 text-white rounded hover:bg-green-700"
+        onClick={() => handleClick('CSV')}
+      >
+        {t('exportCsv')}
+      </button>
     </div>
   );
 }
+

--- a/web/components/LanguageSwitcher.tsx
+++ b/web/components/LanguageSwitcher.tsx
@@ -6,13 +6,19 @@ export default function LanguageSwitcher() {
   const { locale, locales, pathname, query, asPath } = useRouter();
   const t = useTranslations();
   return (
-    <div>
-      <span>{t('language')}: </span>
+    <div className="mb-4 flex items-center gap-2">
+      <span className="font-semibold mr-2">{t('language')}:</span>
       {locales?.map((lng) => (
         <Link key={lng} href={{ pathname, query }} as={asPath} locale={lng}>
-          <button disabled={locale === lng}>{lng}</button>
+          <button
+            className="px-2 py-1 border rounded hover:bg-gray-100 disabled:opacity-50"
+            disabled={locale === lng}
+          >
+            {lng}
+          </button>
         </Link>
       ))}
     </div>
   );
 }
+

--- a/web/components/RankCard.tsx
+++ b/web/components/RankCard.tsx
@@ -1,0 +1,29 @@
+import { FC } from 'react';
+
+interface Props {
+  name: string;
+  score: number;
+  rank: number;
+  reasons: Record<string, number>;
+}
+
+const medalClasses = ['bg-yellow-400', 'bg-slate-300', 'bg-amber-600'];
+
+const RankCard: FC<Props> = ({ name, score, rank, reasons }) => {
+  const ribbon = rank <= 3 ? medalClasses[rank - 1] : 'bg-gray-200';
+  return (
+    <div className="relative p-4 bg-white rounded-lg shadow animate-fadeIn">
+      <div className={`absolute -top-2 -left-2 px-2 py-1 text-sm text-white rounded ${ribbon}`}>#{rank}</div>
+      <h2 className="text-xl font-bold mb-2">{name}</h2>
+      <p className="text-2xl font-extrabold mb-2">{score} pt</p>
+      <ul className="space-y-1">
+        {Object.entries(reasons).map(([k, v]) => (
+          <li key={k} className="text-sm bg-gray-100 rounded px-2 py-0.5 inline-block mr-2 mb-1">+{v} pt {k}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default RankCard;
+

--- a/web/components/SaveHistoryButton.tsx
+++ b/web/components/SaveHistoryButton.tsx
@@ -21,6 +21,12 @@ export default function SaveHistoryButton({ data }: { data: any }) {
   };
 
   return (
-    <button onClick={handleSave}>{t('saveHistory')}</button>
+    <button
+      className="px-3 py-1 bg-purple-600 text-white rounded hover:bg-purple-700"
+      onClick={handleSave}
+    >
+      {t('saveHistory')}
+    </button>
   );
 }
+

--- a/web/globals.css
+++ b/web/globals.css
@@ -1,0 +1,16 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  body {
+    @apply p-4 font-sans;
+  }
+}
+
+@layer components {
+  .buttons {
+    @apply mt-5 flex gap-2;
+  }
+}
+

--- a/web/package.json
+++ b/web/package.json
@@ -9,8 +9,16 @@
   },
   "dependencies": {
     "next": "14.0.4",
+    "next-intl": "3.4.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "next-intl": "3.4.0"
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "22.15.30",
+    "@types/react": "19.1.6",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.4",
+    "tailwindcss": "^3.3.5",
+    "typescript": "5.8.3"
   }
 }

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,7 +1,7 @@
 import type { AppProps } from 'next/app';
 import { NextIntlClientProvider } from 'next-intl';
 import { useRouter } from 'next/router';
-import '../styles.css';
+import '../globals.css';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   const { locale } = useRouter();

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -5,12 +5,15 @@ import Link from 'next/link';
 export default function Home() {
   const t = useTranslations();
   return (
-    <div>
+    <div className="max-w-xl mx-auto text-center mt-20">
       <LanguageSwitcher />
-      <h1>{t('title')}</h1>
+      <h1 className="text-4xl font-bold mb-8">{t('title')}</h1>
       <Link href="/results">
-        <button>Go to results</button>
+        <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+          Go to results
+        </button>
       </Link>
     </div>
   );
 }
+

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -1,27 +1,32 @@
 import LanguageSwitcher from '../components/LanguageSwitcher';
 import ExportButtons from '../components/ExportButtons';
 import SaveHistoryButton from '../components/SaveHistoryButton';
+import RankCard from '../components/RankCard';
 import { useTranslations } from 'next-intl';
 
 export default function Results() {
   const t = useTranslations();
   const dummyResults = [
-    { name: 'Item A', score: 95, rank: 1 },
-    { name: 'Item B', score: 80, rank: 2 },
-    { name: 'Item C', score: 70, rank: 3 }
+    { name: 'Item A', score: 95, rank: 1, reasons: { quality: 40, design: 30, popularity: 25 } },
+    { name: 'Item B', score: 80, rank: 2, reasons: { quality: 35, design: 25, popularity: 20 } },
+    { name: 'Item C', score: 70, rank: 3, reasons: { quality: 30, design: 20, popularity: 20 } },
+    { name: 'Item D', score: 60, rank: 4, reasons: { quality: 25, design: 20, popularity: 15 } }
   ];
 
   return (
-    <div>
+    <div className="max-w-2xl mx-auto">
       <LanguageSwitcher />
-      <h1>{t('title')}</h1>
-      <ul>
+      <h1 className="text-3xl font-bold mb-4">{t('title')}</h1>
+      <div className="space-y-4">
         {dummyResults.map((item) => (
-          <li key={item.rank}>{item.rank}. {item.name} ({item.score})</li>
+          <RankCard key={item.rank} {...item} />
         ))}
-      </ul>
-      <ExportButtons />
-      <SaveHistoryButton data={dummyResults} />
+      </div>
+      <div className="mt-6 flex gap-2">
+        <ExportButtons />
+        <SaveHistoryButton data={dummyResults} />
+      </div>
     </div>
   );
 }
+

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,3 +1,0 @@
-body { font-family: sans-serif; padding: 20px; }
-.buttons { margin-top: 20px; }
-.buttons button { margin-right: 10px; }

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {
+      keyframes: {
+        fadeIn: { '0%': { opacity: 0 }, '100%': { opacity: 1 } }
+      },
+      animation: {
+        fadeIn: 'fadeIn 0.5s ease-in forwards'
+      }
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- install TailwindCSS and tooling
- redesign pages with modern card-style ranking list
- highlight top ranks using gold/silver/bronze ribbons
- add styled language switcher and action buttons
- show criteria contributions on each result

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684443d5492c8323b825f2ad416a5e26