### PR TITLE
Implement ranking input page

### DIFF
--- a/web/components/CandidateInputs.tsx
+++ b/web/components/CandidateInputs.tsx
@@ -1,0 +1,46 @@
+import { Plus, X } from 'lucide-react';
+import { Dispatch, SetStateAction } from 'react';
+
+interface Props {
+  candidates: string[];
+  setCandidates: Dispatch<SetStateAction<string[]>>;
+}
+
+export default function CandidateInputs({ candidates, setCandidates }: Props) {
+  const update = (value: string, idx: number) => {
+    const list = [...candidates];
+    list[idx] = value;
+    setCandidates(list);
+  };
+  const add = () => setCandidates([...candidates, '']);
+  const remove = (idx: number) =>
+    setCandidates(candidates.filter((_, i) => i !== idx));
+
+  return (
+    <div className="space-y-2">
+      {candidates.map((c, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <input
+            className="flex-1 p-2 border rounded"
+            placeholder="Item"
+            value={c}
+            onChange={(e) => update(e.target.value, i)}
+          />
+          {candidates.length > 1 && (
+            <button
+              type="button"
+              onClick={() => remove(i)}
+              className="p-2 text-red-500"
+            >
+              <X size={18} />
+            </button>
+          )}
+        </div>
+      ))}
+      <button type="button" onClick={add} className="flex items-center gap-1 text-sm text-blue-600">
+        <Plus size={16} />
+        Add
+      </button>
+    </div>
+  );
+}

--- a/web/components/CriteriaInputs.tsx
+++ b/web/components/CriteriaInputs.tsx
@@ -1,0 +1,57 @@
+import { Plus, X } from 'lucide-react';
+import { Dispatch, SetStateAction } from 'react';
+
+export interface Criterion {
+  name: string;
+  weight: number;
+}
+
+interface Props {
+  criteria: Criterion[];
+  setCriteria: Dispatch<SetStateAction<Criterion[]>>;
+}
+
+export default function CriteriaInputs({ criteria, setCriteria }: Props) {
+  const update = (idx: number, field: keyof Criterion, value: string | number) => {
+    const list = [...criteria];
+    (list[idx] as any)[field] = field === 'weight' ? Number(value) : value;
+    setCriteria(list);
+  };
+  const add = () => setCriteria([...criteria, { name: '', weight: 3 }]);
+  const remove = (idx: number) => setCriteria(criteria.filter((_, i) => i !== idx));
+
+  return (
+    <div className="space-y-2">
+      {criteria.map((c, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <input
+            className="flex-1 p-2 border rounded"
+            placeholder="Criterion"
+            value={c.name}
+            onChange={(e) => update(i, 'name', e.target.value)}
+          />
+          <select
+            className="p-2 border rounded"
+            value={c.weight}
+            onChange={(e) => update(i, 'weight', e.target.value)}
+          >
+            {[1, 2, 3, 4, 5].map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+          {criteria.length > 1 && (
+            <button type="button" onClick={() => remove(i)} className="p-2 text-red-500">
+              <X size={18} />
+            </button>
+          )}
+        </div>
+      ))}
+      <button type="button" onClick={add} className="flex items-center gap-1 text-sm text-blue-600">
+        <Plus size={16} />
+        Add
+      </button>
+    </div>
+  );
+}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -2,6 +2,10 @@
   "title": "Ranking Results",
   "exportPdf": "Export PDF",
   "exportCsv": "Export CSV",
-  "language": "Language"
-  ,"saveHistory": "Save to history"
+  "language": "Language",
+  "saveHistory": "Save to history",
+  "generate": "Generate Ranking",
+  "addItem": "Add item",
+  "addCriterion": "Add criterion",
+  "weight": "Weight"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -2,6 +2,10 @@
   "title": "ランキング結果",
   "exportPdf": "PDFをエクスポート",
   "exportCsv": "CSVをエクスポート",
-  "language": "言語"
-  ,"saveHistory": "履歴に保存"
+  "language": "言語",
+  "saveHistory": "履歴に保存",
+  "generate": "ランキング生成",
+  "addItem": "候補を追加",
+  "addCriterion": "評価軸を追加",
+  "weight": "重み"
 }

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
     "next": "14.0.4",
     "next-intl": "3.4.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "lucide-react": "^0.379.0"
   },
   "devDependencies": {
     "@types/node": "22.15.30",

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,19 +1,60 @@
-import LanguageSwitcher from '../components/LanguageSwitcher';
+import { useState } from 'react';
+import { useRouter } from 'next/router';
 import { useTranslations } from 'next-intl';
-import Link from 'next/link';
+import LanguageSwitcher from '../components/LanguageSwitcher';
+import CandidateInputs from '../components/CandidateInputs';
+import CriteriaInputs, { Criterion } from '../components/CriteriaInputs';
 
 export default function Home() {
   const t = useTranslations();
+  const router = useRouter();
+  const [candidates, setCandidates] = useState<string[]>(['', '']);
+  const [criteria, setCriteria] = useState<Criterion[]>([{ name: '', weight: 3 }]);
+  const [error, setError] = useState('');
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+  const handleSubmit = async () => {
+    if (candidates.some((c) => !c.trim()) || criteria.some((c) => !c.name.trim())) {
+      setError('Please fill all fields');
+      return;
+    }
+    setError('');
+    const prompt = `Rank the following items: ${candidates.join(', ')}. Criteria with weights: ${criteria
+      .map((c) => `${c.name} (${c.weight})`)
+      .join(', ')}.`;
+    try {
+      const res = await fetch(`${apiUrl}/rank`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt })
+      });
+      const data = await res.json();
+      router.push({ pathname: '/results', query: { data: JSON.stringify(data) } });
+    } catch (e) {
+      alert('Failed to fetch ranking');
+    }
+  };
+
   return (
-    <div className="max-w-xl mx-auto text-center mt-20">
+    <div className="max-w-xl mx-auto mt-10 space-y-6">
       <LanguageSwitcher />
-      <h1 className="text-4xl font-bold mb-8">{t('title')}</h1>
-      <Link href="/results">
-        <button className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
-          Go to results
-        </button>
-      </Link>
+      <h1 className="text-2xl font-bold text-center">{t('generate')}</h1>
+      <section>
+        <h2 className="font-semibold mb-2">Candidates</h2>
+        <CandidateInputs candidates={candidates} setCandidates={setCandidates} />
+      </section>
+      <section>
+        <h2 className="font-semibold mb-2">Criteria</h2>
+        <CriteriaInputs criteria={criteria} setCriteria={setCriteria} />
+      </section>
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <button
+        onClick={handleSubmit}
+        className="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+      >
+        {t('generate')}
+      </button>
     </div>
   );
 }
-

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -3,28 +3,36 @@ import ExportButtons from '../components/ExportButtons';
 import SaveHistoryButton from '../components/SaveHistoryButton';
 import RankCard from '../components/RankCard';
 import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 
 export default function Results() {
   const t = useTranslations();
-  const dummyResults = [
-    { name: 'Item A', score: 95, rank: 1, reasons: { quality: 40, design: 30, popularity: 25 } },
-    { name: 'Item B', score: 80, rank: 2, reasons: { quality: 35, design: 25, popularity: 20 } },
-    { name: 'Item C', score: 70, rank: 3, reasons: { quality: 30, design: 20, popularity: 20 } },
-    { name: 'Item D', score: 60, rank: 4, reasons: { quality: 25, design: 20, popularity: 15 } }
-  ];
+  const router = useRouter();
+  const [results, setResults] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (router.isReady && typeof router.query.data === 'string') {
+      try {
+        setResults(JSON.parse(router.query.data));
+      } catch {
+        setResults([]);
+      }
+    }
+  }, [router.isReady, router.query.data]);
 
   return (
     <div className="max-w-2xl mx-auto">
       <LanguageSwitcher />
       <h1 className="text-3xl font-bold mb-4">{t('title')}</h1>
       <div className="space-y-4">
-        {dummyResults.map((item) => (
+        {results.map((item) => (
           <RankCard key={item.rank} {...item} />
         ))}
       </div>
       <div className="mt-6 flex gap-2">
         <ExportButtons />
-        <SaveHistoryButton data={dummyResults} />
+        <SaveHistoryButton data={results} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow dynamic candidate/criteria form on the top page
- send selections to the backend and show results
- add lucide-react dependency
- support new i18n messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445a50e3d48323a9edd90221f10e40