### PR TITLE
Improve Japanese UI

### DIFF
--- a/web/components/CandidateInputs.tsx
+++ b/web/components/CandidateInputs.tsx
@@ -1,5 +1,6 @@
 import { Plus, X } from 'lucide-react';
 import { Dispatch, SetStateAction } from 'react';
+import { useTranslations } from 'next-intl';
 
 interface Props {
   candidates: string[];
@@ -7,6 +8,8 @@ interface Props {
 }
 
 export default function CandidateInputs({ candidates, setCandidates }: Props) {
+  const t = useTranslations();
+
   const update = (value: string, idx: number) => {
     const list = [...candidates];
     list[idx] = value;
@@ -21,8 +24,8 @@ export default function CandidateInputs({ candidates, setCandidates }: Props) {
       {candidates.map((c, i) => (
         <div key={i} className="flex items-center gap-2">
           <input
-            className="flex-1 p-2 border rounded"
-            placeholder="Item"
+            className="flex-1 p-2 border rounded-md bg-gray-50"
+            placeholder={t('itemPlaceholder')}
             value={c}
             onChange={(e) => update(e.target.value, i)}
           />
@@ -37,9 +40,13 @@ export default function CandidateInputs({ candidates, setCandidates }: Props) {
           )}
         </div>
       ))}
-      <button type="button" onClick={add} className="flex items-center gap-1 text-sm text-blue-600">
+      <button
+        type="button"
+        onClick={add}
+        className="flex items-center gap-1 text-sm text-blue-600 hover:underline"
+      >
         <Plus size={16} />
-        Add
+        {t('addItem')}
       </button>
     </div>
   );

--- a/web/components/CriteriaInputs.tsx
+++ b/web/components/CriteriaInputs.tsx
@@ -1,5 +1,6 @@
 import { Plus, X } from 'lucide-react';
 import { Dispatch, SetStateAction } from 'react';
+import { useTranslations } from 'next-intl';
 
 export interface Criterion {
   name: string;
@@ -12,6 +13,8 @@ interface Props {
 }
 
 export default function CriteriaInputs({ criteria, setCriteria }: Props) {
+  const t = useTranslations();
+
   const update = (idx: number, field: keyof Criterion, value: string | number) => {
     const list = [...criteria];
     (list[idx] as any)[field] = field === 'weight' ? Number(value) : value;
@@ -25,13 +28,13 @@ export default function CriteriaInputs({ criteria, setCriteria }: Props) {
       {criteria.map((c, i) => (
         <div key={i} className="flex items-center gap-2">
           <input
-            className="flex-1 p-2 border rounded"
-            placeholder="Criterion"
+            className="flex-1 p-2 border rounded-md bg-gray-50"
+            placeholder={t('criterionPlaceholder')}
             value={c.name}
             onChange={(e) => update(i, 'name', e.target.value)}
           />
           <select
-            className="p-2 border rounded"
+            className="p-2 border rounded-md bg-gray-50"
             value={c.weight}
             onChange={(e) => update(i, 'weight', e.target.value)}
           >
@@ -48,9 +51,13 @@ export default function CriteriaInputs({ criteria, setCriteria }: Props) {
           )}
         </div>
       ))}
-      <button type="button" onClick={add} className="flex items-center gap-1 text-sm text-blue-600">
+      <button
+        type="button"
+        onClick={add}
+        className="flex items-center gap-1 text-sm text-blue-600 hover:underline"
+      >
         <Plus size={16} />
-        Add
+        {t('addCriterion')}
       </button>
     </div>
   );

--- a/web/components/SaveHistoryButton.tsx
+++ b/web/components/SaveHistoryButton.tsx
@@ -14,9 +14,9 @@ export default function SaveHistoryButton({ data }: { data: any }) {
         },
         body: JSON.stringify(data)
       });
-      alert('Saved!');
+      alert(t('saved'));
     } catch (err) {
-      alert('Failed to save');
+      alert(t('saveFailed'));
     }
   };
 

--- a/web/globals.css
+++ b/web/globals.css
@@ -4,7 +4,7 @@
 
 @layer base {
   body {
-    @apply p-4 font-sans;
+    @apply p-4 font-sans bg-gray-50;
   }
 }
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -7,5 +7,15 @@
   "generate": "Generate Ranking",
   "addItem": "Add item",
   "addCriterion": "Add criterion",
-  "weight": "Weight"
+  "weight": "Weight",
+  "candidates": "Candidates",
+  "criteria": "Criteria",
+  "fillError": "Please fill all fields",
+  "fetchError": "Failed to fetch ranking",
+  "saved": "Saved!",
+  "saveFailed": "Failed to save",
+  "itemPlaceholder": "e.g. Ramen Shop A",
+  "criterionPlaceholder": "e.g. Taste",
+  "instruction": "Enter the items you want to compare and the criteria for scoring them.",
+  "sample": "Insert sample"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -5,7 +5,17 @@
   "language": "言語",
   "saveHistory": "履歴に保存",
   "generate": "ランキング生成",
-  "addItem": "候補を追加",
-  "addCriterion": "評価軸を追加",
-  "weight": "重み"
+  "addItem": "＋追加",
+  "addCriterion": "＋追加",
+  "weight": "重み",
+  "candidates": "比較候補",
+  "criteria": "評価基準",
+  "fillError": "すべての項目を入力してください",
+  "fetchError": "ランキング取得に失敗しました",
+  "saved": "保存しました！",
+  "saveFailed": "保存に失敗しました",
+  "itemPlaceholder": "例: ラーメン屋A",
+  "criterionPlaceholder": "例: 味",
+  "instruction": "比較したい候補と評価基準を入力してください。",
+  "sample": "サンプルを入れる"
 }

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -12,11 +12,20 @@ export default function Home() {
   const [criteria, setCriteria] = useState<Criterion[]>([{ name: '', weight: 3 }]);
   const [error, setError] = useState('');
 
+  const insertSample = () => {
+    setCandidates(['ラーメン屋A', 'ラーメン屋B', 'ラーメン屋C']);
+    setCriteria([
+      { name: '味', weight: 5 },
+      { name: '値段', weight: 4 },
+      { name: 'アクセス', weight: 3 },
+    ]);
+  };
+
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
   const handleSubmit = async () => {
     if (candidates.some((c) => !c.trim()) || criteria.some((c) => !c.name.trim())) {
-      setError('Please fill all fields');
+      setError(t('fillError'));
       return;
     }
     setError('');
@@ -32,7 +41,7 @@ export default function Home() {
       const data = await res.json();
       router.push({ pathname: '/results', query: { data: JSON.stringify(data) } });
     } catch (e) {
-      alert('Failed to fetch ranking');
+      alert(t('fetchError'));
     }
   };
 
@@ -40,18 +49,28 @@ export default function Home() {
     <div className="max-w-xl mx-auto mt-10 space-y-6">
       <LanguageSwitcher />
       <h1 className="text-2xl font-bold text-center">{t('generate')}</h1>
-      <section>
-        <h2 className="font-semibold mb-2">Candidates</h2>
+      <p className="text-center text-sm text-gray-600">{t('instruction')}</p>
+      <div className="text-right">
+        <button
+          type="button"
+          onClick={insertSample}
+          className="text-xs text-blue-600 hover:underline"
+        >
+          {t('sample')}
+        </button>
+      </div>
+      <section className="bg-white p-4 rounded-lg shadow space-y-2">
+        <h2 className="font-semibold mb-2">{t('candidates')}</h2>
         <CandidateInputs candidates={candidates} setCandidates={setCandidates} />
       </section>
-      <section>
-        <h2 className="font-semibold mb-2">Criteria</h2>
+      <section className="bg-white p-4 rounded-lg shadow space-y-2">
+        <h2 className="font-semibold mb-2">{t('criteria')}</h2>
         <CriteriaInputs criteria={criteria} setCriteria={setCriteria} />
       </section>
       {error && <p className="text-red-600 text-sm">{error}</p>}
       <button
         onClick={handleSubmit}
-        className="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        className="w-full py-2 bg-blue-600 text-white rounded-md shadow hover:bg-blue-700 transition"
       >
         {t('generate')}
       </button>

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -22,10 +22,10 @@ export default function Results() {
   }, [router.isReady, router.query.data]);
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <div className="max-w-2xl mx-auto space-y-4">
       <LanguageSwitcher />
       <h1 className="text-3xl font-bold mb-4">{t('title')}</h1>
-      <div className="space-y-4">
+      <div className="space-y-4 bg-white p-4 rounded-lg shadow">
         {results.map((item) => (
           <RankCard key={item.rank} {...item} />
         ))}


### PR DESCRIPTION
## Summary
- localize UI elements and placeholders into Japanese
- add sample data button and usage instructions
- modernize component styling and add card visuals
- translate alert messages

## Testing
- `npm run build --prefix web`

------
https://chatgpt.com/codex/tasks/task_e_6848654e66348323a64163f6843b9712