### PR TITLE
Fix result parsing and request models

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI
+from fastapi import Body, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
 from .services.ranker import RankerService
 from typing import Any, List
 
@@ -15,12 +16,17 @@ app.add_middleware(
 ranker = RankerService()
 history_store: List[Any] = []
 
+
+class RankRequest(BaseModel):
+    prompt: str
+
 @app.post("/rank")
-async def rank(prompt: str):
-    return ranker.rank(prompt)
+async def rank(request: RankRequest):
+    """Generate a ranking based on the provided prompt."""
+    return ranker.rank(request.prompt)
 
 @app.post("/history")
-async def save_history(data: Any):
+async def save_history(data: Any = Body(...)):
     """Store ranking results in-memory."""
     history_store.append(data)
     return {"status": "ok"}

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -14,7 +14,9 @@ export default function Results() {
   useEffect(() => {
     if (router.isReady && typeof router.query.data === 'string') {
       try {
-        setResults(JSON.parse(router.query.data));
+        const parsed = JSON.parse(router.query.data);
+        console.log('results', parsed);
+        setResults(Array.isArray(parsed) ? parsed : parsed.results ?? []);
       } catch {
         setResults([]);
       }
@@ -26,9 +28,8 @@ export default function Results() {
       <LanguageSwitcher />
       <h1 className="text-3xl font-bold mb-4">{t('title')}</h1>
       <div className="space-y-4 bg-white p-4 rounded-lg shadow">
-        {results.map((item) => (
-          <RankCard key={item.rank} {...item} />
-        ))}
+        {Array.isArray(results) &&
+          results.map((item) => <RankCard key={item.rank} {...item} />)}
       </div>
       <div className="mt-6 flex gap-2">
         <ExportButtons />


### PR DESCRIPTION
## Summary
- parse API data safely on the results page
- allow `/rank` endpoint to receive JSON body
- fix `/history` endpoint to read JSON body

## Testing
- `python -m py_compile app/*.py app/services/*.py`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848753d6038832386ed9aa06eb51b87