### PR TITLE
Fix runtime error with next-intl provider

### DIFF
--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,5 +1,7 @@
 import type { AppProps } from 'next/app';
-import { NextIntlProvider } from 'next-intl';
+// NextIntlProvider is not exported in next-intl v3+
+// Using NextIntlClientProvider avoids `undefined` components at runtime
+import { NextIntlClientProvider } from 'next-intl';
 import { useRouter } from 'next/router';
 import '../styles.css';
 
@@ -7,8 +9,8 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   const { locale } = useRouter();
   const messages = require(`../messages/${locale}.json`);
   return (
-    <NextIntlProvider locale={locale!} messages={messages}>
+    <NextIntlClientProvider locale={locale!} messages={messages}>
       <Component {...pageProps} />
-    </NextIntlProvider>
+    </NextIntlClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- switch to `NextIntlClientProvider`
- comment the provider change

## Testing
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_6843ed838b688323bdb0a7498e955f64