### PR TITLE
Fix OpenAI client setup

### DIFF
--- a/server/app/services/ranker.py
+++ b/server/app/services/ranker.py
@@ -1,5 +1,4 @@
 import json
-import os
 from typing import Any, Dict, List
 
 from openai import OpenAI
@@ -12,8 +11,10 @@ class RankerService:
     temperature = 0
 
     def __init__(self) -> None:
-        """Initialize OpenAI client."""
-        self.client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+        """Initialize OpenAI client using environment variables."""
+        # The OpenAI library automatically reads the API key from
+        # the `OPENAI_API_KEY` environment variable.
+        self.client = OpenAI()
 
     def _call_openai(self, prompt: str) -> List[Dict[str, Any]]:
         """Call OpenAI API and return parsed JSON response.

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,3 +1,3 @@
 fastapi==0.111.0
 uvicorn==0.29.0
-openai==1.23.6
+openai==1.86.0


### PR DESCRIPTION
## Summary
- remove direct API key passing to `OpenAI()`
- bump OpenAI to 1.86.0

## Testing
- `python -m py_compile server/app/services/ranker.py`
- `pip install -r server/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684879c398e083239cbace72b305b541