### PR TITLE
Fix OpenAI initialization doc

### DIFF
--- a/server/app/services/ranker.py
+++ b/server/app/services/ranker.py
@@ -11,9 +11,12 @@ class RankerService:
     temperature = 0
 
     def __init__(self) -> None:
-        """Initialize OpenAI client using environment variables."""
-        # The OpenAI library automatically reads the API key from
-        # the `OPENAI_API_KEY` environment variable.
+        """Initialize the OpenAI client without extra parameters."""
+        # openai v1.x automatically reads settings such as
+        # `OPENAI_API_KEY` from environment variables. Passing
+        # unsupported arguments like ``proxies`` or ``api_key`` will
+        # raise ``TypeError`` in recent versions, so we simply
+        # instantiate ``OpenAI()``.
         self.client = OpenAI()
 
     def _call_openai(self, prompt: str) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- clarify comments about OpenAI client initialization

## Testing
- `uvicorn app.main:app --reload` *(fails: uvicorn command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849907cb37083239be8d84d80c056d2