### PR TITLE
Fix openai init error

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.111.0
 uvicorn==0.29.0
 openai==1.86.0
+httpx>=0.23.0


### PR DESCRIPTION
## Summary
- specify compatible `httpx` in `requirements.txt` to avoid `proxies` argument error

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849956a90d083238d64da164546b39a