### PR TITLE
Fix OpenAI requirement version

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.111.0
 uvicorn==0.29.0
-openai==1.86.0
+openai==1.8.6
 httpx>=0.23.0


### PR DESCRIPTION
## Summary
- fix OpenAI package version in requirements.txt

## Testing
- `python3 -m py_compile server/app/services/ranker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684997420c888323b896d034ca5fb5a7