### PR TITLE
Update README about dependency upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,9 @@ npm run dev
 ```
 cd server
 pip install -r requirements.txt
+# After pulling new commits, run the install command again to make sure
+# dependencies such as `openai` and `httpx` are updated.  Old versions of
+# `httpx` can cause errors like `Client.__init__() got an unexpected keyword
+# argument 'proxies'`.
 uvicorn app.main:app --reload
 ```


### PR DESCRIPTION
## Summary
- clarify that `pip install -r requirements.txt` should be run after pulling so dependencies like `openai` and `httpx` are up to date

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849a77086f8832387e40f63484a1b59