### PR TITLE
Fix ranking response structure and add dummy data option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ pip install -r requirements.txt
 # argument 'proxies'`.
 uvicorn app.main:app --reload
 ```
+
+If you don't have an OpenAI API key handy, start the server with
+``USE_DUMMY_DATA=1`` to use built-in sample rankings:
+
+```
+USE_DUMMY_DATA=1 uvicorn app.main:app --reload
+```

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -22,8 +22,13 @@ class RankRequest(BaseModel):
 
 @app.post("/rank")
 async def rank(request: RankRequest):
-    """Generate a ranking based on the provided prompt."""
-    return ranker.rank(request.prompt)
+    """Generate a ranking based on the provided prompt.
+
+    The frontend expects an object with a ``results`` field, so wrap the
+    generated list in that structure.
+    """
+    ranking = ranker.rank(request.prompt)
+    return {"results": ranking}
 
 @app.post("/history")
 async def save_history(data: Any = Body(...)):

--- a/server/app/services/ranker.py
+++ b/server/app/services/ranker.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import re
 from typing import Any, Dict, List
 
@@ -69,5 +70,31 @@ class RankerService:
         raise ValueError("Failed to parse JSON from OpenAI response")
 
     def rank(self, prompt: str) -> List[Dict[str, Any]]:
-        """Public method to generate ranking from a prompt."""
+        """Public method to generate ranking from a prompt.
+
+        If the environment variable ``USE_DUMMY_DATA`` is set, return a static
+        ranking response.  This is helpful for local development when no
+        OpenAI API key is available.
+        """
+        if os.getenv("USE_DUMMY_DATA"):
+            return [
+                {
+                    "name": "Sample A",
+                    "score": 10,
+                    "rank": 1,
+                    "reasons": {"taste": 5, "price": 3},
+                },
+                {
+                    "name": "Sample B",
+                    "score": 8,
+                    "rank": 2,
+                    "reasons": {"taste": 4, "price": 2},
+                },
+                {
+                    "name": "Sample C",
+                    "score": 6,
+                    "rank": 3,
+                    "reasons": {"taste": 3, "price": 1},
+                },
+            ]
         return self._call_openai(prompt)


### PR DESCRIPTION
## Summary
- return an object with a `results` array from the `/rank` endpoint
- allow returning dummy data when `USE_DUMMY_DATA=1`
- document how to run the server with dummy data

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849d3c5b7b48323b9f84607b4efb9b1