### PR TITLE
Add loading feedback and improve result handling

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -17,5 +17,7 @@
   "itemPlaceholder": "e.g. Ramen Shop A",
   "criterionPlaceholder": "e.g. Taste",
   "instruction": "Enter the items you want to compare and the criteria for scoring them.",
-  "sample": "Insert sample"
+  "sample": "Insert sample",
+  "generating": "Generating...",
+  "noResults": "No results found"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -17,5 +17,7 @@
   "itemPlaceholder": "例: ラーメン屋A",
   "criterionPlaceholder": "例: 味",
   "instruction": "比較したい候補と評価基準を入力してください。",
-  "sample": "サンプルを入れる"
+  "sample": "サンプルを入れる",
+  "generating": "生成中...",
+  "noResults": "結果がありません"
 }

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -11,6 +11,7 @@ export default function Home() {
   const [candidates, setCandidates] = useState<string[]>(['', '']);
   const [criteria, setCriteria] = useState<Criterion[]>([{ name: '', weight: 3 }]);
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const insertSample = () => {
     setCandidates(['ラーメン屋A', 'ラーメン屋B', 'ラーメン屋C']);
@@ -29,6 +30,7 @@ export default function Home() {
       return;
     }
     setError('');
+    setLoading(true);
     const prompt = `Rank the following items: ${candidates.join(', ')}. Criteria with weights: ${criteria
       .map((c) => `${c.name} (${c.weight})`)
       .join(', ')}.`;
@@ -39,9 +41,12 @@ export default function Home() {
         body: JSON.stringify({ prompt })
       });
       const data = await res.json();
+      console.log('ranking response', data);
       router.push({ pathname: '/results', query: { data: JSON.stringify(data) } });
     } catch (e) {
       alert(t('fetchError'));
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -70,9 +75,10 @@ export default function Home() {
       {error && <p className="text-red-600 text-sm">{error}</p>}
       <button
         onClick={handleSubmit}
-        className="w-full py-2 bg-blue-600 text-white rounded-md shadow hover:bg-blue-700 transition"
+        disabled={loading}
+        className="w-full py-2 bg-blue-600 text-white rounded-md shadow hover:bg-blue-700 transition disabled:opacity-50"
       >
-        {t('generate')}
+        {loading ? t('generating') : t('generate')}
       </button>
     </div>
   );

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -10,16 +10,20 @@ export default function Results() {
   const t = useTranslations();
   const router = useRouter();
   const [results, setResults] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (router.isReady && typeof router.query.data === 'string') {
-      try {
-        const parsed = JSON.parse(router.query.data);
-        console.log('results', parsed);
-        setResults(Array.isArray(parsed) ? parsed : parsed.results ?? []);
-      } catch {
-        setResults([]);
+    if (router.isReady) {
+      if (typeof router.query.data === 'string') {
+        try {
+          const parsed = JSON.parse(router.query.data);
+          console.log('results', parsed);
+          setResults(Array.isArray(parsed) ? parsed : parsed.results ?? []);
+        } catch {
+          setResults([]);
+        }
       }
+      setLoading(false);
     }
   }, [router.isReady, router.query.data]);
 
@@ -27,9 +31,14 @@ export default function Results() {
     <div className="max-w-2xl mx-auto space-y-4">
       <LanguageSwitcher />
       <h1 className="text-3xl font-bold mb-4">{t('title')}</h1>
-      <div className="space-y-4 bg-white p-4 rounded-lg shadow">
-        {Array.isArray(results) &&
-          results.map((item) => <RankCard key={item.rank} {...item} />)}
+      <div className="space-y-4 bg-white p-4 rounded-lg shadow min-h-[100px] flex items-center justify-center">
+        {loading ? (
+          <p>{t('generating')}</p>
+        ) : results.length === 0 ? (
+          <p>{t('noResults')}</p>
+        ) : (
+          results.map((item) => <RankCard key={item.rank} {...item} />)
+        )}
       </div>
       <div className="mt-6 flex gap-2">
         <ExportButtons />


### PR DESCRIPTION
## Summary
- show progress indicator while generating rankings
- log ranking API responses for debugging
- handle empty results gracefully
- add `generating` and `noResults` translations

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d876478288323ba9b41be41ca86f4