### PR TITLE
Improve logging and loading feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
+The API requires `OPENAI_API_KEY` to be set in the environment. Create a `.env`
+file or export the variable before running the server. When testing without a
+key, set `USE_DUMMY_DATA=1` to return sample rankings.
+
 If you don't have an OpenAI API key handy, start the server with
 ``USE_DUMMY_DATA=1`` to use built-in sample rankings:
 

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -3,6 +3,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from .services.ranker import RankerService
 from typing import Any, List
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
@@ -27,7 +31,9 @@ async def rank(request: RankRequest):
     The frontend expects an object with a ``results`` field, so wrap the
     generated list in that structure.
     """
+    logger.info("Received prompt: %s", request.prompt)
     ranking = ranker.rank(request.prompt)
+    logger.info("Ranking generated: %s", ranking)
     return {"results": ranking}
 
 @app.post("/history")

--- a/server/app/services/ranker.py
+++ b/server/app/services/ranker.py
@@ -48,6 +48,7 @@ class RankerService:
             {"role": "user", "content": prompt},
         ]
 
+        logger.info("Calling OpenAI with prompt: %s", prompt)
         for _ in range(2):
             response = self.client.chat.completions.create(
                 model=self.model,
@@ -57,13 +58,18 @@ class RankerService:
                 response_format={"type": "json_object"},
             )
             content = response.choices[0].message.content
+            logger.info("Raw OpenAI response: %s", content)
             try:
-                return json.loads(content)
+                parsed = json.loads(content)
+                logger.info("Parsed response: %s", parsed)
+                return parsed
             except json.JSONDecodeError:
                 logger.error("OpenAI response not valid JSON: %s", content)
                 cleaned = self._cleanup_json(content)
                 try:
-                    return json.loads(cleaned)
+                    parsed = json.loads(cleaned)
+                    logger.info("Parsed cleaned response: %s", parsed)
+                    return parsed
                 except json.JSONDecodeError:
                     # Retry once more with cleaned content
                     continue
@@ -77,7 +83,7 @@ class RankerService:
         OpenAI API key is available.
         """
         if os.getenv("USE_DUMMY_DATA"):
-            return [
+            data = [
                 {
                     "name": "Sample A",
                     "score": 10,
@@ -97,4 +103,8 @@ class RankerService:
                     "reasons": {"taste": 3, "price": 1},
                 },
             ]
-        return self._call_openai(prompt)
+            logger.info("Returning dummy data: %s", data)
+            return data
+        data = self._call_openai(prompt)
+        logger.info("Returning OpenAI data: %s", data)
+        return data

--- a/web/components/RankCard.tsx
+++ b/web/components/RankCard.tsx
@@ -1,11 +1,7 @@
 import { FC } from 'react';
+import { RankingItem } from '../types';
 
-interface Props {
-  name: string;
-  score: number;
-  rank: number;
-  reasons: Record<string, number>;
-}
+type Props = RankingItem;
 
 const medalClasses = ['bg-yellow-400', 'bg-slate-300', 'bg-amber-600'];
 

--- a/web/components/Spinner.tsx
+++ b/web/components/Spinner.tsx
@@ -1,0 +1,26 @@
+import { FC } from 'react';
+
+const Spinner: FC = () => (
+  <svg
+    className="animate-spin h-5 w-5 text-white"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <circle
+      className="opacity-25"
+      cx="12"
+      cy="12"
+      r="10"
+      stroke="currentColor"
+      strokeWidth="4"
+    />
+    <path
+      className="opacity-75"
+      fill="currentColor"
+      d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+    />
+  </svg>
+);
+
+export default Spinner;

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -5,11 +5,13 @@ import RankCard from '../components/RankCard';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import Spinner from '../components/Spinner';
+import { RankingItem } from '../types';
 
 export default function Results() {
   const t = useTranslations();
   const router = useRouter();
-  const [results, setResults] = useState<any[]>([]);
+  const [results, setResults] = useState<RankingItem[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -17,16 +19,17 @@ export default function Results() {
       if (typeof router.query.data === 'string') {
         try {
           const parsed = JSON.parse(router.query.data);
+          console.log('router query parsed', parsed);
           const arr = Array.isArray(parsed)
             ? parsed
             : Array.isArray(parsed.results)
             ? parsed.results
             : [];
+          console.log('arr', arr);
           setResults(arr);
-          console.log(arr);
-        } catch {
+        } catch (err) {
+          console.error('parse error', err);
           setResults([]);
-          console.log([]);
         }
       }
       setLoading(false);
@@ -45,7 +48,7 @@ export default function Results() {
       <h1 className="text-3xl font-bold mb-4">{t('title')}</h1>
       <div className="space-y-4 bg-white p-4 rounded-lg shadow min-h-[100px] flex items-center justify-center">
         {loading ? (
-          <p>{t('generating')}</p>
+          <div className="flex items-center gap-2"><Spinner />{t('generating')}</div>
         ) : !Array.isArray(results) || results.length === 0 ? (
           <p>{t('noResults')}</p>
         ) : (

--- a/web/types.ts
+++ b/web/types.ts
@@ -1,0 +1,6 @@
+export interface RankingItem {
+  name: string;
+  score: number;
+  rank: number;
+  reasons: Record<string, number>;
+}


### PR DESCRIPTION
## Summary
- add logging of prompts and responses in the FastAPI server
- display a loading spinner while waiting for results
- log API status and prompt in the frontend
- type the ranking results and show spinner on results page
- document OPENAI_API_KEY requirement

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec1c480808323b10a7ab45a481663