### PR TITLE
Handle single ranking result and improve UI

### DIFF
--- a/server/app/services/ranker.py
+++ b/server/app/services/ranker.py
@@ -38,11 +38,13 @@ class RankerService:
         messages = [
             {
                 "role": "system",
-                # Instruct the model to return ONLY a JSON array without markdown or explanations.
+                # Ask the model to respond ONLY with a JSON array. If only a single
+                # result exists, it should still be wrapped in an array. No
+                # markdown or explanatory text is allowed.
                 "content": (
-                    "You are a JSON API. Respond with a pure JSON array where each element "
-                    "has the fields name, score, rank and reasons mapping criterion to reason. "
-                    "Do not include code fences or additional text."
+                    "You are a JSON API. Always respond with a pure JSON array where each "
+                    "element has the fields name, score, rank and reasons mapping criterion "
+                    "to reason. Do not include code fences or additional text."
                 ),
             },
             {"role": "user", "content": prompt},
@@ -62,6 +64,8 @@ class RankerService:
             try:
                 parsed = json.loads(content)
                 logger.info("Parsed response: %s", parsed)
+                if isinstance(parsed, dict):
+                    parsed = [parsed]
                 return parsed
             except json.JSONDecodeError:
                 logger.error("OpenAI response not valid JSON: %s", content)
@@ -69,6 +73,8 @@ class RankerService:
                 try:
                     parsed = json.loads(cleaned)
                     logger.info("Parsed cleaned response: %s", parsed)
+                    if isinstance(parsed, dict):
+                        parsed = [parsed]
                     return parsed
                 except json.JSONDecodeError:
                     # Retry once more with cleaned content
@@ -106,5 +112,7 @@ class RankerService:
             logger.info("Returning dummy data: %s", data)
             return data
         data = self._call_openai(prompt)
+        if isinstance(data, dict):
+            data = [data]
         logger.info("Returning OpenAI data: %s", data)
         return data

--- a/web/components/RankCard.tsx
+++ b/web/components/RankCard.tsx
@@ -7,14 +7,27 @@ const medalClasses = ['bg-yellow-400', 'bg-slate-300', 'bg-amber-600'];
 
 const RankCard: FC<Props> = ({ name, score, rank, reasons }) => {
   const ribbon = rank <= 3 ? medalClasses[rank - 1] : 'bg-gray-200';
+  const borderColor = rank <= 3 ? medalClasses[rank - 1] : 'gray';
   return (
-    <div className="relative p-4 bg-white rounded-lg shadow animate-fadeIn">
-      <div className={`absolute -top-2 -left-2 px-2 py-1 text-sm text-white rounded ${ribbon}`}>#{rank}</div>
-      <h2 className="text-xl font-bold mb-2">{name}</h2>
-      <p className="text-2xl font-extrabold mb-2">{score} pt</p>
-      <ul className="space-y-1">
+    <div
+      className="relative p-4 bg-white rounded-lg shadow hover:shadow-lg transition animate-fadeIn border-l-4"
+      style={{ borderColor: borderColor }}
+    >
+      <div
+        className={`absolute -top-2 -left-2 px-2 py-1 text-sm text-white rounded ${ribbon}`}
+      >
+        #{rank}
+      </div>
+      <h2 className="text-xl font-bold mb-1">{name}</h2>
+      <p className="text-xl font-extrabold mb-2">{score} pt</p>
+      <ul className="flex flex-wrap gap-2">
         {Object.entries(reasons).map(([k, v]) => (
-          <li key={k} className="text-sm bg-gray-100 rounded px-2 py-0.5 inline-block mr-2 mb-1">+{v} pt {k}</li>
+          <li
+            key={k}
+            className="text-sm bg-gray-100 rounded px-2 py-0.5"
+          >
+            +{v} pt {k}
+          </li>
         ))}
       </ul>
     </div>

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -48,11 +48,19 @@ export default function Home() {
       }
       const data = await res.json();
       console.log('ranking response', data);
-      if (!data || !Array.isArray(data.results) || data.results.length === 0) {
+      const resultArray = Array.isArray(data)
+        ? data
+        : Array.isArray(data.results)
+        ? data.results
+        : [data.results ?? data];
+      if (!resultArray || resultArray.length === 0) {
         setError(t('noResults'));
         return;
       }
-      router.push({ pathname: '/results', query: { data: JSON.stringify(data) } });
+      router.push({
+        pathname: '/results',
+        query: { data: JSON.stringify(resultArray) }
+      });
     } catch (e) {
       console.error(e);
       setError(t('fetchError'));

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -24,7 +24,7 @@ export default function Results() {
             ? parsed
             : Array.isArray(parsed.results)
             ? parsed.results
-            : [];
+            : [parsed.results ?? parsed];
           console.log('arr', arr);
           setResults(arr);
         } catch (err) {


### PR DESCRIPTION
## Summary
- request JSON array from OpenAI and wrap dict result in list
- ensure `rank` endpoint always returns list
- robust client parsing of ranking results
- enhance ranking card visuals

## Testing
- `python -m py_compile app/main.py app/services/ranker.py`
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1b2919c48323929c9d9740a179f0