### PR TITLE
Fix ranking data parsing

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -34,6 +34,19 @@ async def rank(request: RankRequest):
     logger.info("Received prompt: %s", request.prompt)
     ranking = ranker.rank(request.prompt)
     logger.info("Ranking generated: %s", ranking)
+    # Older versions of the RankerService or the OpenAI prompt may return a
+    # structure like ``[{"rankings": [...]}]``.  To keep the API stable for the
+    # frontend, unwrap such responses here so that we always return the flat
+    # list of ranking items.
+    if isinstance(ranking, dict) and "rankings" in ranking:
+        ranking = ranking["rankings"]
+    elif (
+        isinstance(ranking, list)
+        and len(ranking) == 1
+        and isinstance(ranking[0], dict)
+        and "rankings" in ranking[0]
+    ):
+        ranking = ranking[0]["rankings"]
     return {"results": ranking}
 
 @app.post("/history")

--- a/web/components/RankCard.tsx
+++ b/web/components/RankCard.tsx
@@ -21,7 +21,7 @@ const RankCard: FC<Props> = ({ name, score, rank, reasons }) => {
       <h2 className="text-xl font-bold mb-1">{name}</h2>
       <p className="text-xl font-extrabold mb-2">{score} pt</p>
       <ul className="flex flex-wrap gap-2">
-        {Object.entries(reasons).map(([k, v]) => (
+        {Object.entries(reasons ?? {}).map(([k, v]) => (
           <li
             key={k}
             className="text-sm bg-gray-100 rounded px-2 py-0.5"

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -48,11 +48,20 @@ export default function Home() {
       }
       const data = await res.json();
       console.log('ranking response', data);
-      const resultArray = Array.isArray(data)
-        ? data
-        : Array.isArray(data.results)
-        ? data.results
-        : [data.results ?? data];
+      let resultArray: any = [];
+      if (Array.isArray(data)) {
+        if (data.length === 1 && data[0]?.rankings) {
+          resultArray = data[0].rankings;
+        } else {
+          resultArray = data;
+        }
+      } else if (Array.isArray(data.results)) {
+        resultArray = data.results;
+      } else if (Array.isArray(data.rankings)) {
+        resultArray = data.rankings;
+      } else {
+        resultArray = [data.results ?? data.rankings ?? data];
+      }
       if (!resultArray || resultArray.length === 0) {
         setError(t('noResults'));
         return;

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -20,13 +20,22 @@ export default function Results() {
         try {
           const parsed = JSON.parse(router.query.data);
           console.log('router query parsed', parsed);
-          const arr = Array.isArray(parsed)
-            ? parsed
-            : Array.isArray(parsed.results)
-            ? parsed.results
-            : [parsed.results ?? parsed];
+          let arr: any = [];
+          if (Array.isArray(parsed)) {
+            if (parsed.length === 1 && parsed[0]?.rankings) {
+              arr = parsed[0].rankings;
+            } else {
+              arr = parsed;
+            }
+          } else if (Array.isArray(parsed.results)) {
+            arr = parsed.results;
+          } else if (Array.isArray(parsed.rankings)) {
+            arr = parsed.rankings;
+          } else {
+            arr = [parsed.results ?? parsed.rankings ?? parsed];
+          }
           console.log('arr', arr);
-          setResults(arr);
+          setResults(arr as RankingItem[]);
         } catch (err) {
           console.error('parse error', err);
           setResults([]);

--- a/web/types.ts
+++ b/web/types.ts
@@ -2,5 +2,5 @@ export interface RankingItem {
   name: string;
   score: number;
   rank: number;
-  reasons: Record<string, number>;
+  reasons?: Record<string, number>;
 }


### PR DESCRIPTION
## Summary
- normalize ranking API response in FastAPI backend
- support `rankings` key in Next.js pages
- guard against missing reasons in `RankCard`
- make reasons optional in type definition

## Testing
- `npm run build` *(fails: next not found)*
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68505ef4942083239309f72d3242b737