### PR TITLE
Add Japanese output and Home button

### DIFF
--- a/server/app/services/ranker.py
+++ b/server/app/services/ranker.py
@@ -47,7 +47,10 @@ class RankerService:
                     "to reason. Do not include code fences or additional text."
                 ),
             },
-            {"role": "user", "content": prompt},
+            {
+                "role": "user",
+                "content": f"{prompt}\n\nすべて日本語で回答してください。",
+            },
         ]
 
         logger.info("Calling OpenAI with prompt: %s", prompt)

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -19,5 +19,6 @@
   "instruction": "Enter the items you want to compare and the criteria for scoring them.",
   "sample": "Insert sample",
   "generating": "Generating...",
-  "noResults": "No results found"
+  "noResults": "No results found",
+  "backHome": "Back to Home"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -19,5 +19,6 @@
   "instruction": "比較したい候補と評価基準を入力してください。",
   "sample": "サンプルを入れる",
   "generating": "生成中...",
-  "noResults": "結果がありません"
+  "noResults": "結果がありません",
+  "backHome": "ホームに戻る"
 }

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -51,10 +51,22 @@ export default function Results() {
     }
   }, [results, loading]);
 
+  const goHome = () => {
+    router.push('/');
+  };
+
   return (
     <div className="max-w-2xl mx-auto space-y-4">
       <LanguageSwitcher />
-      <h1 className="text-3xl font-bold mb-4">{t('title')}</h1>
+      <h1 className="text-3xl font-bold text-center">{t('title')}</h1>
+      <div className="text-center">
+        <button
+          onClick={goHome}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          {t('backHome')}
+        </button>
+      </div>
       <div className="space-y-4 bg-white p-4 rounded-lg shadow min-h-[100px] flex items-center justify-center">
         {loading ? (
           <div className="flex items-center gap-2"><Spinner />{t('generating')}</div>


### PR DESCRIPTION
## Summary
- ensure all ranking results are returned in Japanese by modifying the OpenAI prompt
- add a "ホームに戻る" button on the results page
- include translation strings for the new button

## Testing
- `npm run build` *(fails: `next` not found)*
- `pip install -r requirements.txt` *(fails: could not fetch packages)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685065fd7f008323bca6b415f3c6cb33