### PR TITLE
Implement detailed Japanese reasons

### DIFF
--- a/server/app/services/ranker.py
+++ b/server/app/services/ranker.py
@@ -43,13 +43,19 @@ class RankerService:
                 # markdown or explanatory text is allowed.
                 "content": (
                     "You are a JSON API. Always respond with a pure JSON array where each "
-                    "element has the fields name, score, rank and reasons mapping criterion "
-                    "to reason. Do not include code fences or additional text."
+                    "element has the fields name, score, rank and reasons mapping each "
+                    "criterion to a Japanese sentence explaining the evaluation. "
+                    "Do not include code fences or additional text."
                 ),
             },
             {
                 "role": "user",
-                "content": f"{prompt}\n\nすべて日本語で回答してください。",
+                "content": (
+                    f"{prompt}\n\n"
+                    "各候補について各評価基準ごとに1文以上で理由を日本語で説明し、"
+                    "次の形式のJSON配列のみを返してください。"
+                    "[{'name':'','score':0,'rank':0,'reasons':{'基準':'理由'}}]"
+                ),
             },
         ]
 
@@ -97,19 +103,19 @@ class RankerService:
                     "name": "Sample A",
                     "score": 10,
                     "rank": 1,
-                    "reasons": {"taste": 5, "price": 3},
+                    "reasons": {"味": "とても美味しい", "値段": "手頃な価格"},
                 },
                 {
                     "name": "Sample B",
                     "score": 8,
                     "rank": 2,
-                    "reasons": {"taste": 4, "price": 2},
+                    "reasons": {"味": "そこそこ美味しい", "値段": "少し高め"},
                 },
                 {
                     "name": "Sample C",
                     "score": 6,
                     "rank": 3,
-                    "reasons": {"taste": 3, "price": 1},
+                    "reasons": {"味": "普通", "値段": "高い"},
                 },
             ]
             logger.info("Returning dummy data: %s", data)

--- a/web/components/RankCard.tsx
+++ b/web/components/RankCard.tsx
@@ -20,13 +20,14 @@ const RankCard: FC<Props> = ({ name, score, rank, reasons }) => {
       </div>
       <h2 className="text-xl font-bold mb-1">{name}</h2>
       <p className="text-xl font-extrabold mb-2">{score} pt</p>
-      <ul className="flex flex-wrap gap-2">
+      <ul className="space-y-1 mt-2">
         {Object.entries(reasons ?? {}).map(([k, v]) => (
           <li
             key={k}
-            className="text-sm bg-gray-100 rounded px-2 py-0.5"
+            className="text-sm bg-gray-50 rounded px-2 py-1 shadow"
           >
-            +{v} pt {k}
+            <span className="font-semibold mr-1">{k}:</span>
+            {v}
           </li>
         ))}
       </ul>

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -20,5 +20,6 @@
   "sample": "Insert sample",
   "generating": "Generating...",
   "noResults": "No results found",
-  "backHome": "Back to Home"
+  "backHome": "Back to Home",
+  "formatError": "Invalid response format"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -20,5 +20,6 @@
   "sample": "サンプルを入れる",
   "generating": "生成中...",
   "noResults": "結果がありません",
-  "backHome": "ホームに戻る"
+  "backHome": "ホームに戻る",
+  "formatError": "レスポンス形式が正しくありません"
 }

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -66,6 +66,18 @@ export default function Home() {
         setError(t('noResults'));
         return;
       }
+      if (
+        !Array.isArray(resultArray) ||
+        resultArray.some(
+          (r) =>
+            !r || typeof r.name !== 'string' ||
+            r.score === undefined ||
+            r.rank === undefined
+        )
+      ) {
+        setError(t('formatError'));
+        return;
+      }
       router.push({
         pathname: '/results',
         query: { data: JSON.stringify(resultArray) }

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -67,7 +67,7 @@ export default function Results() {
           {t('backHome')}
         </button>
       </div>
-      <div className="space-y-4 bg-white p-4 rounded-lg shadow min-h-[100px] flex items-center justify-center">
+      <div className="space-y-4 bg-white p-4 rounded-lg shadow min-h-[100px] flex flex-col items-stretch justify-start overflow-y-auto max-h-[70vh]">
         {loading ? (
           <div className="flex items-center gap-2"><Spinner />{t('generating')}</div>
         ) : !Array.isArray(results) || results.length === 0 ? (

--- a/web/types.ts
+++ b/web/types.ts
@@ -2,5 +2,5 @@ export interface RankingItem {
   name: string;
   score: number;
   rank: number;
-  reasons?: Record<string, number>;
+  reasons?: Record<string, string>;
 }


### PR DESCRIPTION
## Summary
- require Japanese reasons for each criterion in the OpenAI prompt
- update dummy data to include textual reasons
- show reasons text on ranking cards
- validate API results and show a new error message on failure
- allow scrolling results list
- adjust types and locale messages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685068770ae883238b85a3b09a2db7cd