### PR TITLE
Enhance results display and export

### DIFF
--- a/web/components/ExportButtons.tsx
+++ b/web/components/ExportButtons.tsx
@@ -1,21 +1,47 @@
 import { useTranslations } from 'next-intl';
+import { RankingItem } from '../types';
 
-export default function ExportButtons() {
+interface Props {
+  data: RankingItem[];
+}
+
+export default function ExportButtons({ data }: Props) {
   const t = useTranslations();
-  const handleClick = (type: string) => {
-    alert(`${type} export coming soon!`);
+
+  const exportCsv = () => {
+    const headers = ['Rank', 'Name', 'Score', 'Reasons'];
+    const rows = data.map((r) => {
+      const reasons = Object.entries(r.reasons ?? {})
+        .map(([k, v]) => `${k}:${v}`)
+        .join('; ');
+      return [r.rank, r.name, r.score, reasons];
+    });
+    const csv = [headers, ...rows]
+      .map((row) => row.map((c) => `"${String(c).replace(/"/g, '""')}"`).join(','))
+      .join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'ranking.csv';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportPdf = () => {
+    alert(`${t('comingSoon')}: PDF`);
   };
   return (
     <div className="buttons">
       <button
         className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
-        onClick={() => handleClick('PDF')}
+        onClick={exportPdf}
       >
         {t('exportPdf')}
       </button>
       <button
         className="px-3 py-1 bg-green-600 text-white rounded hover:bg-green-700"
-        onClick={() => handleClick('CSV')}
+        onClick={exportCsv}
       >
         {t('exportCsv')}
       </button>

--- a/web/components/RankCard.tsx
+++ b/web/components/RankCard.tsx
@@ -1,11 +1,14 @@
 import { FC } from 'react';
 import { RankingItem } from '../types';
+import { Award } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 
 type Props = RankingItem;
 
 const medalClasses = ['bg-yellow-400', 'bg-slate-300', 'bg-amber-600'];
 
 const RankCard: FC<Props> = ({ name, score, rank, reasons }) => {
+  const t = useTranslations();
   const ribbon = rank <= 3 ? medalClasses[rank - 1] : 'bg-gray-200';
   const borderColor = rank <= 3 ? medalClasses[rank - 1] : 'gray';
   return (
@@ -16,21 +19,23 @@ const RankCard: FC<Props> = ({ name, score, rank, reasons }) => {
       <div
         className={`absolute -top-2 -left-2 px-2 py-1 text-sm text-white rounded ${ribbon}`}
       >
-        #{rank}
+        <div className="flex items-center gap-1">
+          {rank <= 3 && <Award className="w-3 h-3" />}
+          {t('rank')} {rank}
+        </div>
       </div>
-      <h2 className="text-xl font-bold mb-1">{name}</h2>
-      <p className="text-xl font-extrabold mb-2">{score} pt</p>
-      <ul className="space-y-1 mt-2">
-        {Object.entries(reasons ?? {}).map(([k, v]) => (
-          <li
-            key={k}
-            className="text-sm bg-gray-50 rounded px-2 py-1 shadow"
-          >
-            <span className="font-semibold mr-1">{k}:</span>
-            {v}
-          </li>
-        ))}
-      </ul>
+      <h2 className="text-xl font-bold mb-1">{name || 'N/A'}</h2>
+      <p className="text-xl font-extrabold mb-2">{t('score')}: {score ?? '-'}</p>
+      {reasons && Object.keys(reasons).length > 0 && (
+        <ul className="list-disc list-inside space-y-1 mt-2 text-sm">
+          {Object.entries(reasons).map(([k, v]) => (
+            <li key={k} className="bg-gray-50 rounded px-2 py-1 shadow">
+              <span className="font-semibold mr-1">{k}:</span>
+              {v}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 };

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -21,5 +21,8 @@
   "generating": "Generating...",
   "noResults": "No results found",
   "backHome": "Back to Home",
-  "formatError": "Invalid response format"
+  "formatError": "Invalid response format",
+  "rank": "Rank",
+  "score": "Score",
+  "comingSoon": "Coming soon"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -21,5 +21,8 @@
   "generating": "生成中...",
   "noResults": "結果がありません",
   "backHome": "ホームに戻る",
-  "formatError": "レスポンス形式が正しくありません"
+  "formatError": "レスポンス形式が正しくありません",
+  "rank": "順位",
+  "score": "スコア",
+  "comingSoon": "近日公開"
 }

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -13,6 +13,7 @@ export default function Results() {
   const router = useRouter();
   const [results, setResults] = useState<RankingItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     if (router.isReady) {
@@ -35,9 +36,13 @@ export default function Results() {
             arr = [parsed.results ?? parsed.rankings ?? parsed];
           }
           console.log('arr', arr);
-          setResults(arr as RankingItem[]);
+          const sorted = (arr as RankingItem[]).sort((a, b) =>
+            (a.rank ?? 0) - (b.rank ?? 0)
+          );
+          setResults(sorted);
         } catch (err) {
           console.error('parse error', err);
+          setError(t('formatError'));
           setResults([]);
         }
       }
@@ -67,17 +72,23 @@ export default function Results() {
           {t('backHome')}
         </button>
       </div>
-      <div className="space-y-4 bg-white p-4 rounded-lg shadow min-h-[100px] flex flex-col items-stretch justify-start overflow-y-auto max-h-[70vh]">
+      <div className="bg-white p-4 rounded-lg shadow min-h-[100px] max-h-[70vh] overflow-y-auto">
         {loading ? (
-          <div className="flex items-center gap-2"><Spinner />{t('generating')}</div>
-        ) : !Array.isArray(results) || results.length === 0 ? (
+          <div className="flex items-center gap-2 justify-center"><Spinner />{t('generating')}</div>
+        ) : error ? (
+          <p className="text-red-600 text-center">{error}</p>
+        ) : results.length === 0 ? (
           <p>{t('noResults')}</p>
         ) : (
-          results.map((item) => <RankCard key={item.rank} {...item} />)
+          <div className="grid gap-4 sm:grid-cols-2">
+            {results.map((item) => (
+              <RankCard key={item.rank} {...item} />
+            ))}
+          </div>
         )}
       </div>
       <div className="mt-6 flex gap-2">
-        <ExportButtons />
+        <ExportButtons data={results} />
         <SaveHistoryButton data={results} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show all ranking cards with improved layout
- add CSV export and placeholder for PDF export
- support rank and score translations
- add error handling to results page
- modernize RankCard with icons and bullet list

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ad674bf88323ba8ee4ebf544f650