### PR TITLE
Improve ranking handling and UI

### DIFF
--- a/server/app/services/ranker.py
+++ b/server/app/services/ranker.py
@@ -26,9 +26,20 @@ class RankerService:
         self.client = OpenAI()
 
     def _cleanup_json(self, text: str) -> str:
-        """Try to extract a JSON array from a text blob."""
+        """Try to extract a JSON object or array from a text blob."""
+        match = re.search(r"{.*}\s*$", text, re.DOTALL)
+        if match:
+            return match.group(0)
         match = re.search(r"\[.*\]", text, re.DOTALL)
         return match.group(0) if match else text
+
+    def _expected_count(self, prompt: str) -> int:
+        """Return the number of candidates found in the prompt."""
+        m = re.search(r"Rank the following items:\s*(.*?)\.\s*Criteria", prompt, re.IGNORECASE)
+        if not m:
+            return -1
+        items = [c.strip() for c in m.group(1).split(',') if c.strip()]
+        return len(items)
 
     def _call_openai(self, prompt: str) -> List[Dict[str, Any]]:
         """Call OpenAI API and return parsed JSON response.
@@ -38,23 +49,20 @@ class RankerService:
         messages = [
             {
                 "role": "system",
-                # Ask the model to respond ONLY with a JSON array. If only a single
-                # result exists, it should still be wrapped in an array. No
-                # markdown or explanatory text is allowed.
                 "content": (
-                    "You are a JSON API. Always respond with a pure JSON array where each "
-                    "element has the fields name, score, rank and reasons mapping each "
-                    "criterion to a Japanese sentence explaining the evaluation. "
-                    "Do not include code fences or additional text."
+                    "You are a JSON API. Always respond with an object that has a "
+                    "'rankings' field containing a JSON array of objects. Each object "
+                    "must include name, score, rank and reasons mapping each criterion "
+                    "to a Japanese sentence explaining the evaluation. Do not include "
+                    "code fences or additional text."
                 ),
             },
             {
                 "role": "user",
                 "content": (
                     f"{prompt}\n\n"
-                    "各候補について各評価基準ごとに1文以上で理由を日本語で説明し、"
-                    "次の形式のJSON配列のみを返してください。"
-                    "[{'name':'','score':0,'rank':0,'reasons':{'基準':'理由'}}]"
+                    "すべての候補を順位順に含む 'rankings' 配列だけを返してください。"
+                    "形式例: {\"rankings\": [{\"name\":\"\",\"score\":0,\"rank\":0,\"reasons\":{\"基準\":\"理由\"}}]}"
                 ),
             },
         ]
@@ -74,6 +82,8 @@ class RankerService:
                 parsed = json.loads(content)
                 logger.info("Parsed response: %s", parsed)
                 if isinstance(parsed, dict):
+                    parsed = parsed.get("rankings", parsed)
+                if isinstance(parsed, dict):
                     parsed = [parsed]
                 return parsed
             except json.JSONDecodeError:
@@ -83,6 +93,8 @@ class RankerService:
                     parsed = json.loads(cleaned)
                     logger.info("Parsed cleaned response: %s", parsed)
                     if isinstance(parsed, dict):
+                        parsed = parsed.get("rankings", parsed)
+                    if isinstance(parsed, dict):
                         parsed = [parsed]
                     return parsed
                 except json.JSONDecodeError:
@@ -90,7 +102,7 @@ class RankerService:
                     continue
         raise ValueError("Failed to parse JSON from OpenAI response")
 
-    def rank(self, prompt: str) -> List[Dict[str, Any]]:
+    def rank(self, prompt: str, expected_count: int | None = None) -> List[Dict[str, Any]]:
         """Public method to generate ranking from a prompt.
 
         If the environment variable ``USE_DUMMY_DATA`` is set, return a static
@@ -120,8 +132,19 @@ class RankerService:
             ]
             logger.info("Returning dummy data: %s", data)
             return data
-        data = self._call_openai(prompt)
-        if isinstance(data, dict):
-            data = [data]
-        logger.info("Returning OpenAI data: %s", data)
-        return data
+        expected = expected_count if expected_count and expected_count > 0 else self._expected_count(prompt)
+        for attempt in range(2):
+            data = self._call_openai(prompt)
+            if isinstance(data, dict):
+                data = [data]
+            if expected <= 1 or len(data) >= expected:
+                logger.info("Returning OpenAI data: %s", data)
+                return data
+            logger.warning(
+                "OpenAI returned %d items, expected %d. Retrying...",
+                len(data),
+                expected,
+            )
+        raise ValueError(
+            f"Incomplete rankings: expected {expected}, got {len(data)}"
+        )

--- a/web/components/ExportButtons.tsx
+++ b/web/components/ExportButtons.tsx
@@ -34,8 +34,9 @@ export default function ExportButtons({ data }: Props) {
   return (
     <div className="buttons">
       <button
-        className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+        className="px-3 py-1 bg-blue-400 text-white rounded cursor-not-allowed opacity-60"
         onClick={exportPdf}
+        disabled
       >
         {t('exportPdf')}
       </button>

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -32,15 +32,20 @@ export default function Home() {
     }
     setError('');
     setLoading(true);
-    const prompt = `Rank the following items: ${candidates.join(', ')}. Criteria with weights: ${criteria
-      .map((c) => `${c.name} (${c.weight})`)
-      .join(', ')}.`;
+    const prompt = [
+      `Rank the following items: ${candidates.join(', ')}.`,
+      `Criteria with weights: ${criteria
+        .map((c) => `${c.name} (${c.weight})`)
+        .join(', ')}.`,
+      "Return all candidates as JSON {\"rankings\": [{\"name\":\"\",\"score\":0,\"rank\":0,\"reasons\":{}}]}.",
+      "Reasons must be in Japanese."
+    ].join(' ');
     console.log('prompt', prompt);
     try {
       const res = await fetch(`${apiUrl}/rank`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt })
+        body: JSON.stringify({ prompt, count: candidates.length })
       });
       console.log('rank api status', res.status);
       if (!res.ok) {


### PR DESCRIPTION
## Summary
- ensure full rankings from OpenAI by requesting all candidates explicitly
- retry if fewer rankings are returned than expected
- expose failure with proper HTTP error handling
- send candidate count from frontend and tweak prompt
- disable unfinished PDF export button

## Testing
- `python -m py_compile server/app/main.py server/app/services/ranker.py`
- `npm install` *(failed: 403 Forbidden)*
- `npm run build` *(failed: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850b162125883239fb3746eb7d9f822