### PR TITLE
Enhance results view with summary and chart

### DIFF
--- a/web/components/RankCard.tsx
+++ b/web/components/RankCard.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 type Props = RankingItem;
 
 const medalClasses = ['bg-yellow-400', 'bg-slate-300', 'bg-amber-600'];
+const medalEmoji = ['🥇', '🥈', '🥉'];
 
 const RankCard: FC<Props> = ({ name, score, rank, reasons }) => {
   const t = useTranslations();
@@ -13,13 +14,14 @@ const RankCard: FC<Props> = ({ name, score, rank, reasons }) => {
   const borderColor = rank <= 3 ? medalClasses[rank - 1] : 'gray';
   return (
     <div
-      className="relative p-4 bg-white rounded-lg shadow hover:shadow-lg transition animate-fadeIn border-l-4"
+      className={`relative p-4 bg-white rounded-lg shadow hover:shadow-lg transition animate-fadeIn border-l-4 ${rank <= 3 ? 'scale-[1.03]' : ''}`}
       style={{ borderColor: borderColor }}
     >
       <div
         className={`absolute -top-2 -left-2 px-2 py-1 text-sm text-white rounded ${ribbon}`}
       >
         <div className="flex items-center gap-1">
+          {rank <= 3 && <span>{medalEmoji[rank - 1]}</span>}
           {rank <= 3 && <Award className="w-3 h-3" />}
           {t('rank')} {rank}
         </div>

--- a/web/components/ScoreChart.tsx
+++ b/web/components/ScoreChart.tsx
@@ -1,0 +1,32 @@
+import { FC } from 'react';
+import { RankingItem } from '../types';
+
+interface Props {
+  results: RankingItem[];
+}
+
+const ScoreChart: FC<Props> = ({ results }) => {
+  if (!results || results.length === 0) return null;
+  const max = Math.max(...results.map((r) => r.score ?? 0));
+  if (max <= 0) return null;
+  return (
+    <div className="space-y-4">
+      {results.map((r) => (
+        <div key={r.rank} className="space-y-1">
+          <div className="flex justify-between text-sm">
+            <span>{r.name}</span>
+            <span>{r.score}</span>
+          </div>
+          <div className="bg-gray-200 h-2 rounded">
+            <div
+              className="bg-blue-500 h-2 rounded"
+              style={{ width: `${(r.score / max) * 100}%` }}
+            ></div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ScoreChart;

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -24,5 +24,8 @@
   "formatError": "Invalid response format",
   "rank": "Rank",
   "score": "Score",
-  "comingSoon": "Coming soon"
+  "comingSoon": "Coming soon",
+  "summary": "Top item is {item}!",
+  "reRank": "Start Over",
+  "scoreChart": "Score Chart"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -24,5 +24,8 @@
   "formatError": "レスポンス形式が正しくありません",
   "rank": "順位",
   "score": "スコア",
-  "comingSoon": "近日公開"
+  "comingSoon": "近日公開",
+  "summary": "最も評価が高かったのは{name}です！",
+  "reRank": "再ランキング",
+  "scoreChart": "スコアチャート"
 }

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -2,6 +2,7 @@ import LanguageSwitcher from '../components/LanguageSwitcher';
 import ExportButtons from '../components/ExportButtons';
 import SaveHistoryButton from '../components/SaveHistoryButton';
 import RankCard from '../components/RankCard';
+import ScoreChart from '../components/ScoreChart';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -14,6 +15,7 @@ export default function Results() {
   const [results, setResults] = useState<RankingItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [summary, setSummary] = useState('');
 
   useEffect(() => {
     if (router.isReady) {
@@ -40,6 +42,9 @@ export default function Results() {
             (a.rank ?? 0) - (b.rank ?? 0)
           );
           setResults(sorted);
+          if (sorted.length > 0) {
+            setSummary(t('summary', { item: sorted[0].name }));
+          }
         } catch (err) {
           console.error('parse error', err);
           setError(t('formatError'));
@@ -53,8 +58,11 @@ export default function Results() {
   useEffect(() => {
     if (!loading) {
       console.log(results);
+      if (results.length > 0) {
+        setSummary(t('summary', { item: results[0].name }));
+      }
     }
-  }, [results, loading]);
+  }, [results, loading, t]);
 
   const goHome = () => {
     router.push('/');
@@ -72,6 +80,9 @@ export default function Results() {
           {t('backHome')}
         </button>
       </div>
+      {summary && (
+        <p className="text-center font-semibold text-lg">{summary}</p>
+      )}
       <div className="bg-white p-4 rounded-lg shadow min-h-[100px] max-h-[70vh] overflow-y-auto">
         {loading ? (
           <div className="flex items-center gap-2 justify-center"><Spinner />{t('generating')}</div>
@@ -80,16 +91,28 @@ export default function Results() {
         ) : results.length === 0 ? (
           <p>{t('noResults')}</p>
         ) : (
-          <div className="grid gap-4 sm:grid-cols-2">
-            {results.map((item) => (
-              <RankCard key={item.rank} {...item} />
-            ))}
-          </div>
+          <>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {results.map((item) => (
+                <RankCard key={item.rank} {...item} />
+              ))}
+            </div>
+            <div className="mt-6">
+              <h2 className="font-semibold mb-2">{t('scoreChart')}</h2>
+              <ScoreChart results={results} />
+            </div>
+          </>
         )}
       </div>
-      <div className="mt-6 flex gap-2">
+      <div className="mt-6 flex gap-2 flex-wrap">
         <ExportButtons data={results} />
         <SaveHistoryButton data={results} />
+        <button
+          onClick={goHome}
+          className="px-3 py-1 bg-gray-600 text-white rounded hover:bg-gray-700"
+        >
+          {t('reRank')}
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show medal emoji and highlight for top ranks
- add summary comment with translation strings
- provide simple score chart component
- display chart and rerank option on results page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68570da419fc8323a70d7f9c9ede4264