### PR TITLE
Add table view and weight slider

### DIFF
--- a/web/components/CriteriaInputs.tsx
+++ b/web/components/CriteriaInputs.tsx
@@ -33,17 +33,17 @@ export default function CriteriaInputs({ criteria, setCriteria }: Props) {
             value={c.name}
             onChange={(e) => update(i, 'name', e.target.value)}
           />
-          <select
-            className="p-2 border rounded-md bg-gray-50"
-            value={c.weight}
-            onChange={(e) => update(i, 'weight', e.target.value)}
-          >
-            {[1, 2, 3, 4, 5].map((n) => (
-              <option key={n} value={n}>
-                {n}
-              </option>
-            ))}
-          </select>
+          <div className="flex items-center gap-1">
+            <input
+              type="range"
+              min={1}
+              max={5}
+              step={1}
+              value={c.weight}
+              onChange={(e) => update(i, 'weight', e.target.value)}
+            />
+            <span className="text-sm w-5 text-center">{c.weight}</span>
+          </div>
           {criteria.length > 1 && (
             <button type="button" onClick={() => remove(i)} className="p-2 text-red-500">
               <X size={18} />

--- a/web/components/TableView.tsx
+++ b/web/components/TableView.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { RankingItem } from '../types';
+import { useTranslations } from 'next-intl';
+
+interface Props {
+  results: RankingItem[];
+}
+
+export default function TableView({ results }: Props) {
+  const t = useTranslations();
+  const [field, setField] = useState<'rank' | 'name' | 'score'>('rank');
+  const [asc, setAsc] = useState(true);
+
+  const toggle = (f: 'rank' | 'name' | 'score') => {
+    if (field === f) setAsc(!asc);
+    else {
+      setField(f);
+      setAsc(true);
+    }
+  };
+
+  const sorted = [...results].sort((a, b) => {
+    const valA = a[field];
+    const valB = b[field];
+    if (valA < valB) return asc ? -1 : 1;
+    if (valA > valB) return asc ? 1 : -1;
+    return 0;
+  });
+
+  return (
+    <table className="min-w-full text-sm border">
+      <thead>
+        <tr className="bg-gray-100">
+          <th className="cursor-pointer p-2" onClick={() => toggle('rank')}>
+            {t('rank')}
+          </th>
+          <th className="cursor-pointer p-2" onClick={() => toggle('name')}>
+            {t('name') ?? 'Name'}
+          </th>
+          <th className="cursor-pointer p-2" onClick={() => toggle('score')}>
+            {t('score')}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {sorted.map((r) => (
+          <tr key={r.rank} className="border-t">
+            <td className="p-2 text-center">{r.rank}</td>
+            <td className="p-2">{r.name}</td>
+            <td className="p-2 text-right">{r.score}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -24,8 +24,11 @@
   "formatError": "Invalid response format",
   "rank": "Rank",
   "score": "Score",
+  "name": "Name",
   "comingSoon": "Coming soon",
   "summary": "Top item is {item}!",
   "reRank": "Start Over",
-  "scoreChart": "Score Chart"
+  "scoreChart": "Score Chart",
+  "cardView": "Card View",
+  "tableView": "Table View"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -24,8 +24,11 @@
   "formatError": "レスポンス形式が正しくありません",
   "rank": "順位",
   "score": "スコア",
+  "name": "名前",
   "comingSoon": "近日公開",
   "summary": "最も評価が高かったのは{name}です！",
   "reRank": "再ランキング",
-  "scoreChart": "スコアチャート"
+  "scoreChart": "スコアチャート",
+  "cardView": "カード表示",
+  "tableView": "テーブル表示"
 }

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -3,6 +3,7 @@ import ExportButtons from '../components/ExportButtons';
 import SaveHistoryButton from '../components/SaveHistoryButton';
 import RankCard from '../components/RankCard';
 import ScoreChart from '../components/ScoreChart';
+import TableView from '../components/TableView';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -16,6 +17,7 @@ export default function Results() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [summary, setSummary] = useState('');
+  const [view, setView] = useState<'card' | 'table'>('card');
 
   useEffect(() => {
     if (router.isReady) {
@@ -80,6 +82,20 @@ export default function Results() {
           {t('backHome')}
         </button>
       </div>
+      <div className="flex justify-center gap-2">
+        <button
+          className={`px-3 py-1 rounded ${view === 'card' ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+          onClick={() => setView('card')}
+        >
+          {t('cardView')}
+        </button>
+        <button
+          className={`px-3 py-1 rounded ${view === 'table' ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+          onClick={() => setView('table')}
+        >
+          {t('tableView')}
+        </button>
+      </div>
       {summary && (
         <p className="text-center font-semibold text-lg">{summary}</p>
       )}
@@ -92,11 +108,15 @@ export default function Results() {
           <p>{t('noResults')}</p>
         ) : (
           <>
-            <div className="grid gap-4 sm:grid-cols-2">
-              {results.map((item) => (
-                <RankCard key={item.rank} {...item} />
-              ))}
-            </div>
+            {view === 'card' ? (
+              <div className="grid gap-4 sm:grid-cols-2">
+                {results.map((item) => (
+                  <RankCard key={item.rank} {...item} />
+                ))}
+              </div>
+            ) : (
+              <TableView results={results} />
+            )}
             <div className="mt-6">
               <h2 className="font-semibold mb-2">{t('scoreChart')}</h2>
               <ScoreChart results={results} />


### PR DESCRIPTION
## Summary
- use slider input for criteria weight
- add a sortable table view for results
- allow switching between card and table views
- update translations

## Testing
- `npm run build` *(fails: next not found)*
- `pip install -r requirements.txt` *(fails: connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68585c6fd078832380dde9c1ea5c32b3