### PR TITLE
Add radar chart visualizations

### DIFF
--- a/web/components/CriteriaRadar.tsx
+++ b/web/components/CriteriaRadar.tsx
@@ -1,0 +1,55 @@
+import { FC } from 'react';
+import { RankingItem } from '../types';
+import { Radar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  Legend
+);
+
+interface Props {
+  results: RankingItem[];
+}
+
+const CriteriaRadar: FC<Props> = ({ results }) => {
+  if (!results || results.length === 0) return null;
+  const criteria = Object.keys(results[0].reasons ?? {});
+  if (criteria.length === 0) return <p>No criteria data</p>;
+
+  const datasets = results.map((r, idx) => {
+    const color = `hsla(${(idx * 60) % 360},70%,50%,0.5)`;
+    return {
+      label: r.name,
+      data: criteria.map((c) => {
+        const text = r.reasons?.[c] || '';
+        return Math.min(text.length, 100);
+      }),
+      backgroundColor: color,
+      borderColor: color.replace('0.5', '1'),
+      borderWidth: 1,
+    };
+  });
+
+  const data = { labels: criteria, datasets };
+
+  return (
+    <div className="max-w-md mx-auto">
+      <Radar data={data} />
+    </div>
+  );
+};
+
+export default CriteriaRadar;

--- a/web/components/ScoreChart.tsx
+++ b/web/components/ScoreChart.tsx
@@ -1,5 +1,24 @@
 import { FC } from 'react';
 import { RankingItem } from '../types';
+import { Radar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  Legend
+);
 
 interface Props {
   results: RankingItem[];
@@ -7,24 +26,23 @@ interface Props {
 
 const ScoreChart: FC<Props> = ({ results }) => {
   if (!results || results.length === 0) return null;
-  const max = Math.max(...results.map((r) => r.score ?? 0));
-  if (max <= 0) return null;
+
+  const data = {
+    labels: results.map((r) => r.name),
+    datasets: [
+      {
+        label: 'Score',
+        data: results.map((r) => r.score),
+        backgroundColor: 'rgba(54, 162, 235, 0.2)',
+        borderColor: 'rgba(54, 162, 235, 1)',
+        borderWidth: 1,
+      },
+    ],
+  };
+
   return (
-    <div className="space-y-4">
-      {results.map((r) => (
-        <div key={r.rank} className="space-y-1">
-          <div className="flex justify-between text-sm">
-            <span>{r.name}</span>
-            <span>{r.score}</span>
-          </div>
-          <div className="bg-gray-200 h-2 rounded">
-            <div
-              className="bg-blue-500 h-2 rounded"
-              style={{ width: `${(r.score / max) * 100}%` }}
-            ></div>
-          </div>
-        </div>
-      ))}
+    <div className="max-w-md mx-auto">
+      <Radar data={data} />
     </div>
   );
 };

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -30,5 +30,6 @@
   "reRank": "Start Over",
   "scoreChart": "Score Chart",
   "cardView": "Card View",
-  "tableView": "Table View"
+  "tableView": "Table View",
+  "visualAnalysis": "Visual Analysis"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -30,5 +30,6 @@
   "reRank": "再ランキング",
   "scoreChart": "スコアチャート",
   "cardView": "カード表示",
-  "tableView": "テーブル表示"
+  "tableView": "テーブル表示",
+  "visualAnalysis": "ビジュアル分析"
 }

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,9 @@
     "next-intl": "3.4.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "lucide-react": "^0.379.0"
+    "lucide-react": "^0.379.0",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.3.1"
   },
   "devDependencies": {
     "@types/node": "22.15.30",

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -4,6 +4,7 @@ import SaveHistoryButton from '../components/SaveHistoryButton';
 import RankCard from '../components/RankCard';
 import ScoreChart from '../components/ScoreChart';
 import TableView from '../components/TableView';
+import CriteriaRadar from '../components/CriteriaRadar';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -17,7 +18,7 @@ export default function Results() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [summary, setSummary] = useState('');
-  const [view, setView] = useState<'card' | 'table'>('card');
+  const [view, setView] = useState<'card' | 'table' | 'analysis'>('card');
 
   useEffect(() => {
     if (router.isReady) {
@@ -95,6 +96,12 @@ export default function Results() {
         >
           {t('tableView')}
         </button>
+        <button
+          className={`px-3 py-1 rounded ${view === 'analysis' ? 'bg-blue-600 text-white' : 'bg-gray-200'}`}
+          onClick={() => setView('analysis')}
+        >
+          {t('visualAnalysis')}
+        </button>
       </div>
       {summary && (
         <p className="text-center font-semibold text-lg">{summary}</p>
@@ -114,8 +121,10 @@ export default function Results() {
                   <RankCard key={item.rank} {...item} />
                 ))}
               </div>
-            ) : (
+            ) : view === 'table' ? (
               <TableView results={results} />
+            ) : (
+              <CriteriaRadar results={results} />
             )}
             <div className="mt-6">
               <h2 className="font-semibold mb-2">{t('scoreChart')}</h2>


### PR DESCRIPTION
## Summary
- swap bar chart for Chart.js radar chart
- add CriteriaRadar chart for criteria comparison
- introduce Visual Analysis view in results page
- localize Visual Analysis button
- depend on `chart.js` and `react-chartjs-2`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858dcb0fdf08323b7848d981f8c3c89