### PR TITLE
Use localStorage to pass ranking data

### DIFF
--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -83,10 +83,10 @@ export default function Home() {
         setError(t('formatError'));
         return;
       }
-      router.push({
-        pathname: '/results',
-        query: { data: JSON.stringify(resultArray) }
-      });
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('rankingData', JSON.stringify(resultArray));
+      }
+      router.push('/results');
     } catch (e) {
       console.error(e);
       setError(t('fetchError'));

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -20,11 +20,11 @@ export default function Results() {
   const [view, setView] = useState<'card' | 'table'>('card');
 
   useEffect(() => {
-    if (router.isReady) {
-      if (typeof router.query.data === 'string') {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('rankingData');
+      if (stored) {
         try {
-          const parsed = JSON.parse(router.query.data);
-          console.log('router query parsed', parsed);
+          const parsed = JSON.parse(stored);
           let arr: any = [];
           if (Array.isArray(parsed)) {
             if (parsed.length === 1 && parsed[0]?.rankings) {
@@ -39,7 +39,6 @@ export default function Results() {
           } else {
             arr = [parsed.results ?? parsed.rankings ?? parsed];
           }
-          console.log('arr', arr);
           const sorted = (arr as RankingItem[]).sort((a, b) =>
             (a.rank ?? 0) - (b.rank ?? 0)
           );
@@ -52,10 +51,13 @@ export default function Results() {
           setError(t('formatError'));
           setResults([]);
         }
+      } else {
+        setError(t('noResults'));
       }
-      setLoading(false);
+      localStorage.removeItem('rankingData');
     }
-  }, [router.isReady, router.query.data]);
+    setLoading(false);
+  }, [t]);
 
   useEffect(() => {
     if (!loading) {


### PR DESCRIPTION
## Summary
- save ranking results into localStorage on submit
- load and remove ranking results from localStorage on the results page

## Testing
- `python3 -m py_compile server/app/main.py`
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6858dbae37d8832389dbd1c29f552217