### PR TITLE
Add theme colors and unify UI styles

### DIFF
--- a/web/components/ExportButtons.tsx
+++ b/web/components/ExportButtons.tsx
@@ -34,14 +34,14 @@ export default function ExportButtons({ data }: Props) {
   return (
     <div className="buttons">
       <button
-        className="px-3 py-1 bg-blue-400 text-white rounded cursor-not-allowed opacity-60"
+        className="btn btn-primary btn-disabled"
         onClick={exportPdf}
         disabled
       >
         {t('exportPdf')}
       </button>
       <button
-        className="px-3 py-1 bg-green-600 text-white rounded hover:bg-green-700"
+        className="btn btn-accent"
         onClick={exportCsv}
       >
         {t('exportCsv')}

--- a/web/components/RankCard.tsx
+++ b/web/components/RankCard.tsx
@@ -14,7 +14,7 @@ const RankCard: FC<Props> = ({ name, score, rank, reasons }) => {
   const borderColor = rank <= 3 ? medalClasses[rank - 1] : 'gray';
   return (
     <div
-      className={`relative p-4 bg-white rounded-lg shadow hover:shadow-lg transition animate-fadeIn border-l-4 ${rank <= 3 ? 'scale-[1.03]' : ''}`}
+      className={`relative card hover:shadow-lg transition animate-fadeIn border-l-4 ${rank <= 3 ? 'scale-[1.03]' : ''}`}
       style={{ borderColor: borderColor }}
     >
       <div

--- a/web/components/SaveHistoryButton.tsx
+++ b/web/components/SaveHistoryButton.tsx
@@ -22,7 +22,7 @@ export default function SaveHistoryButton({ data }: { data: any }) {
 
   return (
     <button
-      className="px-3 py-1 bg-purple-600 text-white rounded hover:bg-purple-700"
+      className="btn btn-accent"
       onClick={handleSave}
     >
       {t('saveHistory')}

--- a/web/globals.css
+++ b/web/globals.css
@@ -2,13 +2,30 @@
 @tailwind components;
 @tailwind utilities;
 
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap');
+
 @layer base {
   body {
-    @apply p-4 font-sans bg-gray-50;
+    @apply p-4 font-sans bg-background;
   }
 }
 
 @layer components {
+  .btn {
+    @apply px-3 py-1 rounded text-white transition font-medium;
+  }
+  .btn-primary {
+    @apply bg-primary hover:bg-primary-dark;
+  }
+  .btn-accent {
+    @apply bg-accent hover:bg-accent-dark;
+  }
+  .btn-disabled {
+    @apply cursor-not-allowed opacity-60;
+  }
+  .card {
+    @apply bg-white p-4 rounded-lg shadow;
+  }
   .buttons {
     @apply mt-5 flex gap-2;
   }

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -5,13 +5,31 @@ module.exports = {
   ],
   theme: {
     extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#3b82f6',
+          dark: '#2563eb'
+        },
+        accent: {
+          DEFAULT: '#10b981',
+          dark: '#059669'
+        },
+        background: '#f9fafb'
+      },
+      spacing: {
+        section: '1.5rem',
+        page: '2rem'
+      },
+      fontFamily: {
+        sans: ['\'Noto Sans JP\'', 'sans-serif']
+      },
       keyframes: {
         fadeIn: { '0%': { opacity: 0 }, '100%': { opacity: 1 } }
       },
       animation: {
         fadeIn: 'fadeIn 0.5s ease-in forwards'
       }
-    },
+    }
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- extend Tailwind config with custom colors, font and spacing
- import Noto Sans JP and define shared button and card styles
- refactor RankCard, ExportButtons and SaveHistoryButton to use unified classes

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858dbacd8e88323950933abc87931f1