### PR TITLE
Apply container layout and spacing improvements

### DIFF
--- a/web/components/CandidateInputs.tsx
+++ b/web/components/CandidateInputs.tsx
@@ -43,7 +43,7 @@ export default function CandidateInputs({ candidates, setCandidates }: Props) {
       <button
         type="button"
         onClick={add}
-        className="flex items-center gap-1 text-sm text-blue-600 hover:underline"
+        className="flex items-center gap-2 text-sm text-blue-600 hover:underline"
       >
         <Plus size={16} />
         {t('addItem')}

--- a/web/components/CriteriaInputs.tsx
+++ b/web/components/CriteriaInputs.tsx
@@ -33,7 +33,7 @@ export default function CriteriaInputs({ criteria, setCriteria }: Props) {
             value={c.name}
             onChange={(e) => update(i, 'name', e.target.value)}
           />
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-2">
             <input
               type="range"
               min={1}
@@ -54,7 +54,7 @@ export default function CriteriaInputs({ criteria, setCriteria }: Props) {
       <button
         type="button"
         onClick={add}
-        className="flex items-center gap-1 text-sm text-blue-600 hover:underline"
+        className="flex items-center gap-2 text-sm text-blue-600 hover:underline"
       >
         <Plus size={16} />
         {t('addCriterion')}

--- a/web/components/RankCard.tsx
+++ b/web/components/RankCard.tsx
@@ -18,21 +18,21 @@ const RankCard: FC<Props> = ({ name, score, rank, reasons }) => {
       style={{ borderColor: borderColor }}
     >
       <div
-        className={`absolute -top-2 -left-2 px-2 py-1 text-sm text-white rounded ${ribbon}`}
+        className={`absolute -top-2 -left-2 px-2 py-2 text-sm text-white rounded ${ribbon}`}
       >
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-2">
           {rank <= 3 && <span>{medalEmoji[rank - 1]}</span>}
           {rank <= 3 && <Award className="w-3 h-3" />}
           {t('rank')} {rank}
         </div>
       </div>
-      <h2 className="text-xl font-bold mb-1">{name || 'N/A'}</h2>
+      <h2 className="text-xl font-bold mb-2">{name || 'N/A'}</h2>
       <p className="text-xl font-extrabold mb-2">{t('score')}: {score ?? '-'}</p>
       {reasons && Object.keys(reasons).length > 0 && (
-        <ul className="list-disc list-inside space-y-1 mt-2 text-sm">
+        <ul className="list-disc list-inside space-y-2 mt-2 text-sm">
           {Object.entries(reasons).map(([k, v]) => (
-            <li key={k} className="bg-gray-50 rounded px-2 py-1 shadow">
-              <span className="font-semibold mr-1">{k}:</span>
+            <li key={k} className="bg-gray-50 rounded px-2 py-2 shadow">
+              <span className="font-semibold mr-2">{k}:</span>
               {v}
             </li>
           ))}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -96,10 +96,11 @@ export default function Home() {
   };
 
   return (
-    <div className="max-w-xl mx-auto mt-10 space-y-6">
-      <LanguageSwitcher />
-      <h1 className="text-2xl font-bold text-center">{t('generate')}</h1>
-      <p className="text-center text-sm text-gray-600">{t('instruction')}</p>
+    <div className="max-w-[1280px] mx-auto px-4">
+      <div className="max-w-xl mx-auto mt-10 space-y-6">
+        <LanguageSwitcher />
+        <h1 className="text-3xl font-bold text-center">{t('generate')}</h1>
+        <p className="text-center text-sm text-gray-600">{t('instruction')}</p>
       <div className="text-right">
         <button
           type="button"
@@ -110,11 +111,11 @@ export default function Home() {
         </button>
       </div>
       <section className="bg-white p-4 rounded-lg shadow space-y-2">
-        <h2 className="font-semibold mb-2">{t('candidates')}</h2>
+        <h2 className="text-xl font-semibold mb-2">{t('candidates')}</h2>
         <CandidateInputs candidates={candidates} setCandidates={setCandidates} />
       </section>
       <section className="bg-white p-4 rounded-lg shadow space-y-2">
-        <h2 className="font-semibold mb-2">{t('criteria')}</h2>
+        <h2 className="text-xl font-semibold mb-2">{t('criteria')}</h2>
         <CriteriaInputs criteria={criteria} setCriteria={setCriteria} />
       </section>
       {error && <p className="text-red-600 text-sm">{error}</p>}
@@ -126,6 +127,7 @@ export default function Home() {
         {loading && <Spinner />}
         {loading ? t('generating') : t('generate')}
       </button>
+      </div>
     </div>
   );
 }

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -71,8 +71,9 @@ export default function Results() {
   };
 
   return (
-    <div className="max-w-2xl mx-auto space-y-4">
-      <LanguageSwitcher />
+    <div className="max-w-[1280px] mx-auto px-4">
+      <div className="max-w-2xl mx-auto space-y-4">
+        <LanguageSwitcher />
       <h1 className="text-3xl font-bold text-center">{t('title')}</h1>
       <div className="text-center">
         <button
@@ -118,7 +119,7 @@ export default function Results() {
               <TableView results={results} />
             )}
             <div className="mt-6">
-              <h2 className="font-semibold mb-2">{t('scoreChart')}</h2>
+              <h2 className="text-xl font-semibold mb-2">{t('scoreChart')}</h2>
               <ScoreChart results={results} />
             </div>
           </>
@@ -135,6 +136,7 @@ export default function Results() {
         </button>
       </div>
     </div>
+  </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- wrap pages in a max-width container
- apply 8px spacing system to input components and rank card
- adjust heading sizes for consistency

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858dbadf6048323b5d3d436b80177c1