### PR TITLE
Implement landing page and sharing features

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -90,6 +90,16 @@ async def history():
     return _read_history()
 
 
+@app.get("/history/{item_id}")
+async def get_history(item_id: str):
+    """Retrieve a single history item by ID."""
+    items = _read_history()
+    for item in items:
+        if item.get("id") == item_id:
+            return item
+    raise HTTPException(status_code=404, detail="Item not found")
+
+
 @app.delete("/history/{item_id}")
 async def delete_history(item_id: str):
     """Delete a history entry by its ID."""

--- a/web/components/CriteriaRadar.tsx
+++ b/web/components/CriteriaRadar.tsx
@@ -22,9 +22,10 @@ ChartJS.register(
 
 interface Props {
   results: RankingItem[];
+  full?: boolean;
 }
 
-const CriteriaRadar: FC<Props> = ({ results }) => {
+const CriteriaRadar: FC<Props> = ({ results, full }) => {
   if (!results || results.length === 0) return null;
   const criteria = Object.keys(results[0].reasons ?? {});
   if (criteria.length === 0) return <p>No criteria data</p>;
@@ -46,7 +47,7 @@ const CriteriaRadar: FC<Props> = ({ results }) => {
   const data = { labels: criteria, datasets };
 
   return (
-    <div className="max-w-md mx-auto">
+    <div className={full ? 'max-w-full mx-auto' : 'max-w-md mx-auto'}>
       <Radar data={data} />
     </div>
   );

--- a/web/components/RankCard.tsx
+++ b/web/components/RankCard.tsx
@@ -14,7 +14,7 @@ const RankCard: FC<Props> = ({ name, score, rank, reasons }) => {
   const borderColor = rank <= 3 ? medalClasses[rank - 1] : 'gray';
   return (
     <div
-      className={`relative card hover:shadow-lg transition animate-fadeIn border-l-4 ${rank <= 3 ? 'scale-[1.03]' : ''}`}
+      className={`relative card flex hover:shadow-lg transition animate-fadeIn border-l-4 ${rank <= 3 ? 'scale-[1.03]' : ''}`}
       style={{ borderColor: borderColor }}
     >
       <div
@@ -26,18 +26,22 @@ const RankCard: FC<Props> = ({ name, score, rank, reasons }) => {
           {t('rank')} {rank}
         </div>
       </div>
-      <h2 className="text-xl font-bold mb-2">{name || 'N/A'}</h2>
-      <p className="text-xl font-extrabold mb-2">{t('score')}: {score ?? '-'}</p>
-      {reasons && Object.keys(reasons).length > 0 && (
-        <ul className="list-disc list-inside space-y-2 mt-2 text-sm">
-          {Object.entries(reasons).map(([k, v]) => (
-            <li key={k} className="bg-gray-50 rounded px-2 py-2 shadow">
-              <span className="font-semibold mr-2">{k}:</span>
-              {v}
-            </li>
-          ))}
-        </ul>
-      )}
+      <div className="w-1/3 pr-4 border-r">
+        <h2 className="text-2xl font-bold mb-2">{name || 'N/A'}</h2>
+        <p className="text-xl font-extrabold">{t('score')}: {score ?? '-'}</p>
+      </div>
+      <div className="w-2/3 pl-4">
+        {reasons && Object.keys(reasons).length > 0 && (
+          <ul className="list-disc list-inside space-y-2 text-sm">
+            {Object.entries(reasons).map(([k, v]) => (
+              <li key={k} className="bg-gray-50 rounded px-2 py-2 shadow">
+                <span className="font-semibold mr-2">{k}:</span>
+                {v}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </div>
   );
 };

--- a/web/components/ShareButton.tsx
+++ b/web/components/ShareButton.tsx
@@ -1,0 +1,28 @@
+import { useTranslations } from 'next-intl';
+
+export default function ShareButton({ data }: { data: any }) {
+  const t = useTranslations();
+
+  const handleShare = async () => {
+    try {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+      const res = await fetch(`${apiUrl}/history`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      const saved = await res.json();
+      const url = `${window.location.origin}/results?id=${saved.id}`;
+      await navigator.clipboard.writeText(url);
+      alert(`URL copied: ${url}`);
+    } catch (e) {
+      alert('Share failed');
+    }
+  };
+
+  return (
+    <button className="btn btn-primary" onClick={handleShare}>
+      {t('share')}
+    </button>
+  );
+}

--- a/web/globals.css
+++ b/web/globals.css
@@ -6,7 +6,7 @@
 
 @layer base {
   body {
-    @apply p-4 font-sans bg-background;
+    @apply p-4 font-sans bg-background text-[16px];
   }
 }
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -32,4 +32,5 @@
   "cardView": "Card View",
   "tableView": "Table View",
   "visualAnalysis": "Visual Analysis"
+  ,"share": "Share"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -32,4 +32,5 @@
   "cardView": "カード表示",
   "tableView": "テーブル表示",
   "visualAnalysis": "ビジュアル分析"
+  ,"share": "共有"
 }

--- a/web/pages/create.tsx
+++ b/web/pages/create.tsx
@@ -1,0 +1,133 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { useTranslations } from 'next-intl';
+import LanguageSwitcher from '../components/LanguageSwitcher';
+import CandidateInputs from '../components/CandidateInputs';
+import CriteriaInputs, { Criterion } from '../components/CriteriaInputs';
+import Spinner from '../components/Spinner';
+
+export default function Create() {
+  const t = useTranslations();
+  const router = useRouter();
+  const [candidates, setCandidates] = useState<string[]>(['', '']);
+  const [criteria, setCriteria] = useState<Criterion[]>([{ name: '', weight: 3 }]);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const insertSample = () => {
+    setCandidates(['ラーメン屋A', 'ラーメン屋B', 'ラーメン屋C']);
+    setCriteria([
+      { name: '味', weight: 5 },
+      { name: '値段', weight: 4 },
+      { name: 'アクセス', weight: 3 },
+    ]);
+  };
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+  const handleSubmit = async () => {
+    if (candidates.some((c) => !c.trim()) || criteria.some((c) => !c.name.trim())) {
+      setError(t('fillError'));
+      return;
+    }
+    setError('');
+    setLoading(true);
+    const prompt = [
+      `Rank the following items: ${candidates.join(', ')}.`,
+      `Criteria with weights: ${criteria
+        .map((c) => `${c.name} (${c.weight})`)
+        .join(', ')}.`,
+      "Return all candidates as JSON {\"rankings\": [{\"name\":\"\",\"score\":0,\"rank\":0,\"reasons\":{}}]}.",
+      "Reasons must be in Japanese."
+    ].join(' ');
+    console.log('prompt', prompt);
+    try {
+      const res = await fetch(`${apiUrl}/rank`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt, count: candidates.length })
+      });
+      console.log('rank api status', res.status);
+      if (!res.ok) {
+        throw new Error('status ' + res.status);
+      }
+      const data = await res.json();
+      console.log('ranking response', data);
+      let resultArray: any = [];
+      if (Array.isArray(data)) {
+        if (data.length === 1 && data[0]?.rankings) {
+          resultArray = data[0].rankings;
+        } else {
+          resultArray = data;
+        }
+      } else if (Array.isArray(data.results)) {
+        resultArray = data.results;
+      } else if (Array.isArray(data.rankings)) {
+        resultArray = data.rankings;
+      } else {
+        resultArray = [data.results ?? data.rankings ?? data];
+      }
+      if (!resultArray || resultArray.length === 0) {
+        setError(t('noResults'));
+        return;
+      }
+      if (
+        !Array.isArray(resultArray) ||
+        resultArray.some(
+          (r) =>
+            !r || typeof r.name !== 'string' ||
+            r.score === undefined ||
+            r.rank === undefined
+        )
+      ) {
+        setError(t('formatError'));
+        return;
+      }
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('rankingData', JSON.stringify(resultArray));
+      }
+      router.push('/results');
+    } catch (e) {
+      console.error(e);
+      setError(t('fetchError'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-[1280px] mx-auto px-4">
+      <div className="max-w-xl mx-auto mt-10 space-y-6">
+        <LanguageSwitcher />
+        <h1 className="text-3xl font-bold text-center">{t('generate')}</h1>
+        <p className="text-center text-sm text-gray-600">{t('instruction')}</p>
+      <div className="text-right">
+        <button
+          type="button"
+          onClick={insertSample}
+          className="text-xs text-blue-600 hover:underline"
+        >
+          {t('sample')}
+        </button>
+      </div>
+      <section className="bg-white p-4 rounded-lg shadow space-y-2">
+        <h2 className="text-xl font-semibold mb-2">{t('candidates')}</h2>
+        <CandidateInputs candidates={candidates} setCandidates={setCandidates} />
+      </section>
+      <section className="bg-white p-4 rounded-lg shadow space-y-2">
+        <h2 className="text-xl font-semibold mb-2">{t('criteria')}</h2>
+        <CriteriaInputs criteria={criteria} setCriteria={setCriteria} />
+      </section>
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <button
+        onClick={handleSubmit}
+        disabled={loading}
+        className="w-full py-2 bg-blue-600 text-white rounded-md shadow hover:bg-blue-700 transition disabled:opacity-50 flex items-center justify-center gap-2"
+      >
+        {loading && <Spinner />}
+        {loading ? t('generating') : t('generate')}
+      </button>
+      </div>
+    </div>
+  );
+}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,133 +1,58 @@
-import { useState } from 'react';
-import { useRouter } from 'next/router';
-import { useTranslations } from 'next-intl';
-import LanguageSwitcher from '../components/LanguageSwitcher';
-import CandidateInputs from '../components/CandidateInputs';
-import CriteriaInputs, { Criterion } from '../components/CriteriaInputs';
-import Spinner from '../components/Spinner';
+import Link from 'next/link';
 
 export default function Home() {
-  const t = useTranslations();
-  const router = useRouter();
-  const [candidates, setCandidates] = useState<string[]>(['', '']);
-  const [criteria, setCriteria] = useState<Criterion[]>([{ name: '', weight: 3 }]);
-  const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
-
-  const insertSample = () => {
-    setCandidates(['ラーメン屋A', 'ラーメン屋B', 'ラーメン屋C']);
-    setCriteria([
-      { name: '味', weight: 5 },
-      { name: '値段', weight: 4 },
-      { name: 'アクセス', weight: 3 },
-    ]);
-  };
-
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-
-  const handleSubmit = async () => {
-    if (candidates.some((c) => !c.trim()) || criteria.some((c) => !c.name.trim())) {
-      setError(t('fillError'));
-      return;
-    }
-    setError('');
-    setLoading(true);
-    const prompt = [
-      `Rank the following items: ${candidates.join(', ')}.`,
-      `Criteria with weights: ${criteria
-        .map((c) => `${c.name} (${c.weight})`)
-        .join(', ')}.`,
-      "Return all candidates as JSON {\"rankings\": [{\"name\":\"\",\"score\":0,\"rank\":0,\"reasons\":{}}]}.",
-      "Reasons must be in Japanese."
-    ].join(' ');
-    console.log('prompt', prompt);
-    try {
-      const res = await fetch(`${apiUrl}/rank`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt, count: candidates.length })
-      });
-      console.log('rank api status', res.status);
-      if (!res.ok) {
-        throw new Error('status ' + res.status);
-      }
-      const data = await res.json();
-      console.log('ranking response', data);
-      let resultArray: any = [];
-      if (Array.isArray(data)) {
-        if (data.length === 1 && data[0]?.rankings) {
-          resultArray = data[0].rankings;
-        } else {
-          resultArray = data;
-        }
-      } else if (Array.isArray(data.results)) {
-        resultArray = data.results;
-      } else if (Array.isArray(data.rankings)) {
-        resultArray = data.rankings;
-      } else {
-        resultArray = [data.results ?? data.rankings ?? data];
-      }
-      if (!resultArray || resultArray.length === 0) {
-        setError(t('noResults'));
-        return;
-      }
-      if (
-        !Array.isArray(resultArray) ||
-        resultArray.some(
-          (r) =>
-            !r || typeof r.name !== 'string' ||
-            r.score === undefined ||
-            r.rank === undefined
-        )
-      ) {
-        setError(t('formatError'));
-        return;
-      }
-      if (typeof window !== 'undefined') {
-        localStorage.setItem('rankingData', JSON.stringify(resultArray));
-      }
-      router.push('/results');
-    } catch (e) {
-      console.error(e);
-      setError(t('fetchError'));
-    } finally {
-      setLoading(false);
-    }
-  };
-
   return (
-    <div className="max-w-[1280px] mx-auto px-4">
-      <div className="max-w-xl mx-auto mt-10 space-y-6">
-        <LanguageSwitcher />
-        <h1 className="text-3xl font-bold text-center">{t('generate')}</h1>
-        <p className="text-center text-sm text-gray-600">{t('instruction')}</p>
-      <div className="text-right">
-        <button
-          type="button"
-          onClick={insertSample}
-          className="text-xs text-blue-600 hover:underline"
-        >
-          {t('sample')}
-        </button>
-      </div>
-      <section className="bg-white p-4 rounded-lg shadow space-y-2">
-        <h2 className="text-xl font-semibold mb-2">{t('candidates')}</h2>
-        <CandidateInputs candidates={candidates} setCandidates={setCandidates} />
+    <div className="max-w-[1100px] mx-auto px-4 text-center space-y-20">
+      <section className="space-y-6 pt-20">
+        <h1 className="text-5xl font-bold">あらゆる『迷い』に、明確な答えを。</h1>
+        <p className="text-lg">複数の選択肢を、あなただけの評価基準で簡単にランキング。直感的なビジュアル分析で、最適な選択をサポートします。</p>
+        <Link href="/create" className="inline-block px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-dark text-xl">無料でランキングを作成する</Link>
       </section>
-      <section className="bg-white p-4 rounded-lg shadow space-y-2">
-        <h2 className="text-xl font-semibold mb-2">{t('criteria')}</h2>
-        <CriteriaInputs criteria={criteria} setCriteria={setCriteria} />
+      <section className="space-y-8">
+        <h2 className="text-3xl font-bold">たった3ステップで、意思決定をサポート</h2>
+        <div className="grid md:grid-cols-3 gap-6">
+          <div className="space-y-2">
+            <div className="text-6xl">1️⃣</div>
+            <h3 className="font-semibold">入力する</h3>
+            <p>比較したい候補と、あなただけの評価基準を入力します。</p>
+          </div>
+          <div className="space-y-2">
+            <div className="text-6xl">2️⃣</div>
+            <h3 className="font-semibold">評価する</h3>
+            <p>各評価基準の重要度（重み）をスライダーで直感的に設定します。</p>
+          </div>
+          <div className="space-y-2">
+            <div className="text-6xl">3️⃣</div>
+            <h3 className="font-semibold">可視化する</h3>
+            <p>AIが瞬時にスコアを計算し、順位とレーダーチャートで結果をわかりやすく可視化します。</p>
+          </div>
+        </div>
       </section>
-      {error && <p className="text-red-600 text-sm">{error}</p>}
-      <button
-        onClick={handleSubmit}
-        disabled={loading}
-        className="w-full py-2 bg-blue-600 text-white rounded-md shadow hover:bg-blue-700 transition disabled:opacity-50 flex items-center justify-center gap-2"
-      >
-        {loading && <Spinner />}
-        {loading ? t('generating') : t('generate')}
-      </button>
-      </div>
+      <section className="space-y-8">
+        <h2 className="text-3xl font-bold">あなたの意思決定を加速させる機能の数々</h2>
+        <div className="grid md:grid-cols-2 gap-6">
+          <div className="p-4 bg-white rounded shadow">
+            <h3 className="font-semibold mb-2">多角的なビジュアル分析</h3>
+            <p>レーダーチャートで強みと弱みが一目瞭然。</p>
+          </div>
+          <div className="p-4 bg-white rounded shadow">
+            <h3 className="font-semibold mb-2">AIによるサマリー</h3>
+            <p>ランキング結果の要点を自動で文章化。</p>
+          </div>
+          <div className="p-4 bg-white rounded shadow">
+            <h3 className="font-semibold mb-2">保存＆共有</h3>
+            <p>作成したランキングを保存し、URLで共有可能。</p>
+          </div>
+          <div className="p-4 bg-white rounded shadow">
+            <h3 className="font-semibold mb-2">柔軟なカスタマイズ</h3>
+            <p>評価基準や重みを自由に追加・編集。</p>
+          </div>
+        </div>
+      </section>
+      <section className="space-y-6 pb-20">
+        <h2 className="text-3xl font-bold">さあ、あなたの最初のランキングを作りましょう</h2>
+        <Link href="/create" className="inline-block px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-dark text-xl">無料でランキングを作成する</Link>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add new landing page with intro sections
- move ranking generator to `/create`
- redesign results layout with single-column cards and full-screen analysis
- add share button that stores results and copies URL
- expose history item retrieval API
- tweak global font size

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e338e3fc8323bb3f33bd79648e9e