### PR TITLE
Add Next.js TypeScript configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ cd web
 npm install
 npm run dev
 ```
+The `web` directory uses TypeScript with a standard `tsconfig.json` configured
+for Next.js. Run `npm run build` to compile the project for production or use
+`npx tsc --noEmit` to perform a type check only.
 
 ### Server (FastAPI)
 ```

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create `web/tsconfig.json` with standard settings
- include `next-env.d.ts` for Next.js type definitions
- document TypeScript build setup in README

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6871eeab59288323be21c53811106b5f