### PR TITLE
Improve Firebase placeholder check and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ cd web
 npm install
 npm run dev
 ```
-The `web` directory uses TypeScript with a standard `tsconfig.json` configured
-for Next.js. Run `npm run build` to compile the project for production or use
-`npx tsc --noEmit` to perform a type check only.
+Run these commands from the `web` directory so that Next.js can read the
+environment variables located there. Copy `web/.env.local.example` to
+`web/.env.local` and replace the `dummy_*` values with your actual Firebase
+credentials before starting the dev server. The `web` directory uses TypeScript
+with a standard `tsconfig.json` configured for Next.js. Run `npm run build` to
+compile the project for production or use `npx tsc --noEmit` to perform a type
+check only.
 
 ### Server (FastAPI)
 ```

--- a/web/firebase.ts
+++ b/web/firebase.ts
@@ -22,7 +22,11 @@ const missingVars = [
   'appId',
 ].filter((key) => {
   const value = (firebaseConfig as Record<string, string | undefined>)[key];
-  return !value || value.includes('your_');
+  return (
+    !value ||
+    value.includes('your_') ||
+    value.startsWith('dummy_')
+  );
 });
 
 if (missingVars.length > 0) {


### PR DESCRIPTION
## Summary
- validate placeholder Firebase values that start with `dummy_`
- document copying `.env.local.example` and using real keys in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687502026df88323bb462a6a89d7eb45