### PR TITLE
Improve firebase env warning

### DIFF
--- a/web/firebase.ts
+++ b/web/firebase.ts
@@ -42,7 +42,10 @@ if (firebaseEnabled) {
   provider = new GoogleAuthProvider();
   db = getFirestore(app);
 } else {
-  console.warn('Firebase disabled: missing env vars');
+  // Log which variables are missing to help with local setup issues
+  console.warn(
+    `Firebase disabled: missing env vars (${missingVars.join(', ')})`
+  );
 }
 
 export { auth, provider, db };


### PR DESCRIPTION
## Summary
- show which environment variables are missing when Firebase is disabled

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68771d33c6b08323a4b78281296d57a7