### PR TITLE
Improve firebase env warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ npm run dev
 ```
 Run these commands from the `web` directory so that Next.js can read the environment variables located there.
 The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the `dummy_*` values with your actual Firebase credentials before starting the dev server.
+If any of the Firebase variables are missing, the frontend logs a message like
+`Firebase disabled: missing env vars (apiKey, authDomain)`. Use this hint to
+verify that all keys are loaded correctly when troubleshooting login issues.
 The `web` directory uses TypeScript with a standard `tsconfig.json` configured for Next.js. Run `npm run build` to
 compile the project for production or use `npx tsc --noEmit` to perform a type
 check only.

--- a/web/firebase.ts
+++ b/web/firebase.ts
@@ -42,7 +42,10 @@ if (firebaseEnabled) {
   provider = new GoogleAuthProvider();
   db = getFirestore(app);
 } else {
-  console.warn('Firebase disabled: missing env vars');
+  // Log which variables are missing to help with local setup issues
+  console.warn(
+    `Firebase disabled: missing env vars (${missingVars.join(', ')})`
+  );
 }
 
 export { auth, provider, db };


### PR DESCRIPTION
## Summary
- show which environment variables are missing when Firebase is disabled
- document the warning in the README

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68771d33c6b08323a4b78281296d57a7