### PR TITLE
feat: add SessionProvider wrapper for app router

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,12 @@
+import '../globals.css';
+import SessionProviderWrapper from './providers/SessionProviderWrapper';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="ja">
+      <body>
+        <SessionProviderWrapper>{children}</SessionProviderWrapper>
+      </body>
+    </html>
+  );
+}

--- a/web/app/providers/SessionProviderWrapper.tsx
+++ b/web/app/providers/SessionProviderWrapper.tsx
@@ -1,0 +1,7 @@
+'use client';
+import { ReactNode } from 'react';
+import { SessionProvider } from 'next-auth/react';
+
+export default function SessionProviderWrapper({ children }: { children: ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}


### PR DESCRIPTION
## Summary
- add `SessionProviderWrapper` client component
- wrap app layout with `SessionProviderWrapper`

## Testing
- `pytest`
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f51e77d3c8323afe81e85a71a8286