### PR TITLE
fix: mark layout as client component

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import '../globals.css';
 import SessionProviderWrapper from './providers/SessionProviderWrapper';
 


### PR DESCRIPTION
## Summary
- ensure root layout executes as a client component so hooks like SessionProvider work correctly

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f77fbbcf88323b9331a0320919fa0