### PR TITLE
Fix auth defaults and server layout

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,9 +1,8 @@
-"use client";
-
 import '../globals.css';
+import { ReactNode } from 'react';
 import SessionProviderWrapper from './providers/SessionProviderWrapper';
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ja">
       <body>

--- a/web/pages/api/auth/[...nextauth].ts
+++ b/web/pages/api/auth/[...nextauth].ts
@@ -1,5 +1,16 @@
 import NextAuth, { type NextAuthOptions } from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
+import crypto from 'crypto';
+
+// Ensure NextAuth has the required runtime configuration even when
+// environment variables are missing.  This allows `npm run dev` to run
+// without manual setup while still supporting user-provided values.
+if (!process.env.NEXTAUTH_URL) {
+  process.env.NEXTAUTH_URL =
+    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000';
+}
+
+const authSecret = process.env.NEXTAUTH_SECRET || crypto.randomBytes(32).toString('hex');
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -13,7 +24,9 @@ export const authOptions: NextAuthOptions = {
         process.env.GOOGLE_OAUTH_CLIENT_SECRET!,
     }),
   ],
-  secret: process.env.NEXTAUTH_SECRET,
+  // Use the provided secret when available, otherwise fall back to a
+  // randomly generated value for development so that login works out of the box.
+  secret: authSecret,
 };
 
 export default NextAuth(authOptions);


### PR DESCRIPTION
## Summary
- ensure app layout is server component and wraps children with session provider
- add default NextAuth secret and URL so dev login works without env vars

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890cdd02f2083239d0c727561d62dcd