### PR TITLE
Fix disabled Google login button

### DIFF
--- a/web/components/SaveHistoryButton.tsx
+++ b/web/components/SaveHistoryButton.tsx
@@ -13,7 +13,7 @@ export default function SaveHistoryButton({ data }: { data: any }) {
     }
     if (!user) {
       alert(t('authRequired'));
-      login();
+      await login();
       return;
     }
     try {

--- a/web/components/ShareButton.tsx
+++ b/web/components/ShareButton.tsx
@@ -25,7 +25,7 @@ export default function ShareButton({ data }: { data: any }) {
 
   const requireAuth = async () => {
     if (authEnabled && !user) {
-      login();
+      await login();
       return false;
     }
     return true;


### PR DESCRIPTION
## Summary
- Always expose Google login button and attempt sign-in on click
- Show alert when auth provider lookup fails
- Await login in share and save actions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689200e388f48323ab8b85e9bcefc5d6