### PR TITLE
Throw on missing Google OAuth env vars

### DIFF
--- a/web/pages/api/auth/[...nextauth].ts
+++ b/web/pages/api/auth/[...nextauth].ts
@@ -6,16 +6,26 @@ import crypto from 'crypto';
 // when NEXTAUTH_SECRET isn't explicitly configured.
 const devSecret = crypto.randomBytes(32).toString('hex');
 
+// Resolve Google OAuth environment variables and provide clear feedback if
+// they are missing. This helps surface misconfigured `.env` files which would
+// otherwise result in a cryptic "client_id is required" error.
+const googleClientId =
+  process.env.GOOGLE_CLIENT_ID ?? process.env.GOOGLE_OAUTH_CLIENT_ID;
+const googleClientSecret =
+  process.env.GOOGLE_CLIENT_SECRET ?? process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+
+// Fail fast if the expected OAuth credentials are not configured.
+if (!googleClientId || !googleClientSecret) {
+  throw new Error(
+    'Missing Google OAuth environment variables. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.',
+  );
+}
+
 export const authOptions: NextAuthOptions = {
   providers: [
     GoogleProvider({
-      // Support both the standard NextAuth variable names and the
-      // previous GOOGLE_OAUTH_* names for backward compatibility.
-      clientId:
-        process.env.GOOGLE_CLIENT_ID ?? process.env.GOOGLE_OAUTH_CLIENT_ID!,
-      clientSecret:
-        process.env.GOOGLE_CLIENT_SECRET ??
-        process.env.GOOGLE_OAUTH_CLIENT_SECRET!,
+      clientId: googleClientId,
+      clientSecret: googleClientSecret,
     }),
   ],
   secret: process.env.NEXTAUTH_SECRET || devSecret,


### PR DESCRIPTION
## Summary
- throw an explicit error when required Google OAuth env vars are missing to avoid cryptic `client_id is required` failures

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68920e0ba96c8323a635b1dc4a7b8b31