### PR TITLE
Add production environment configuration

### DIFF
--- a/web/.env.local
+++ b/web/.env.local
@@ -1,0 +1,19 @@
+# Copy this file to `.env.local` and replace with your keys.
+# Do not wrap values in quotes and avoid trailing spaces.
+# Example environment variables for Google OAuth via NextAuth
+# Base URL for the local API
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Required NextAuth environment variables
+NEXTAUTH_URL=https://myapp.example.com
+# Should be a random 32+ character string
+NEXTAUTH_SECRET=prod_nextauth_secret
+
+GOOGLE_CLIENT_ID=prod_google_client_id
+GOOGLE_CLIENT_SECRET=prod_google_client_secret
+# Client ID can be exposed in the browser for feature toggles
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=prod_google_client_id
+# Legacy variable names also supported:
+# GOOGLE_OAUTH_CLIENT_ID=your_google_client_id
+# GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret
+# NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=your_google_client_id


### PR DESCRIPTION
## Summary
- add production NextAuth and Google OAuth config

## Testing
- `curl -o /dev/null -s -w "%{http_code}\n" http://localhost:3000/api/auth/signin`


------
https://chatgpt.com/codex/tasks/task_e_68937938f90083238fbc0ecc772491a1