### PR TITLE
feat: disable React preload for development

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,5 +1,6 @@
-import "./globals.css";
-import Providers from "@/components/Providers";
+import './react-preload-shim';
+import './globals.css';
+import Providers from '@/components/Providers';
 
 export default async function RootLayout({
   children,

--- a/web/app/react-preload-shim.ts
+++ b/web/app/react-preload-shim.ts
@@ -1,0 +1,4 @@
+import * as ReactDOM from 'react-dom';
+const any = ReactDOM as any;
+if (!any.preload) any.preload = () => {};
+if (!any.preinit) any.preinit = () => {};

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -25,6 +25,10 @@ const nextConfig = {
     defaultLocale: 'en',
   },
   reactStrictMode: true,
+  optimizeFonts: false,
+  experimental: {
+    optimizePackageImports: [],
+  },
   env,
   webpack: (config) => {
     // Ensure all packages, including ones hoisted outside this project, use


### PR DESCRIPTION
## Summary
- disable Next.js font optimization and package import optimization
- introduce React DOM preload shim and import it in root layout

## Testing
- `npm test`
- `npm run build` *(fails: Expected '>', got 'style'; importing component requiring useState without 'use client')*


------
https://chatgpt.com/codex/tasks/task_e_689d73d7acd08323a2bdfa54d62393ff