### PR TITLE
refactor: render language switcher via client component

### DIFF
--- a/web/app/ja/layout.tsx
+++ b/web/app/ja/layout.tsx
@@ -1,11 +1,12 @@
-import '../globals.css';
 import ClientLanguageSwitcher from '@/components/ClientLanguageSwitcher';
 
-export default function JaLayout({ children }: { children: React.ReactNode }) {
+export default function LocaleLayout({ children }: { children: React.ReactNode }) {
   return (
-    <>
-      <ClientLanguageSwitcher />
-      {children}
-    </>
+    <html lang="ja" suppressHydrationWarning>
+      <body className="min-h-screen">
+        <ClientLanguageSwitcher />
+        {children}
+      </body>
+    </html>
   );
 }

--- a/web/components/ClientLanguageSwitcher.tsx
+++ b/web/components/ClientLanguageSwitcher.tsx
@@ -1,4 +1,7 @@
 'use client';
+
 import LanguageSwitcher from './LanguageSwitcher';
-const ClientLanguageSwitcher = (props: React.ComponentProps<typeof LanguageSwitcher>) => <LanguageSwitcher {...props} />;
-export default ClientLanguageSwitcher;
+
+export default function ClientLanguageSwitcher() {
+  return <LanguageSwitcher />;
+}


### PR DESCRIPTION
## Summary
- wrap LanguageSwitcher in a client component for safe server usage
- update ja layout to use ClientLanguageSwitcher and proper HTML structure

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d7931e61083238a01d21b4c4f20d0