### PR TITLE
Disable ReactDOM preloading and isolate language switcher

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,6 +1,6 @@
-import './react-preload-shim';
 import './globals.css';
 import Providers from '@/components/Providers';
+import ReactDOMShimClient from '@/components/ReactDOMShimClient';
 
 export default async function RootLayout({
   children,
@@ -13,8 +13,9 @@ export default async function RootLayout({
   const messages = (await import(`../messages/${locale}.json`)).default;
 
   return (
-    <html lang={locale}>
+    <html lang={locale} suppressHydrationWarning>
       <body className="min-h-screen bg-white text-gray-900 antialiased">
+        <ReactDOMShimClient />
         <Providers messages={messages}>{children}</Providers>
       </body>
     </html>

--- a/web/components/LanguageSwitcher.pages.tsx
+++ b/web/components/LanguageSwitcher.pages.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { useRouter } from 'next/router';
+const LOCALES = ['ja', 'en'] as const;
+
+export default function LanguageSwitcherPages() {
+  const router = useRouter();
+  const pathname = router.asPath || '/';
+  const switchTo = (target: (typeof LOCALES)[number]) => {
+    const segs = pathname.split('/').filter(Boolean);
+    if (LOCALES.includes(segs[0] as any)) segs[0] = target;
+    else segs.unshift(target);
+    router.push('/' + segs.join('/'));
+  };
+  return (
+    <div className="flex gap-2">
+      {LOCALES.map(l => (
+        <button key={l} onClick={() => switchTo(l)} className="px-2 py-1 rounded hover:bg-gray-100">
+          {l}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/components/ReactDOMShimClient.tsx
+++ b/web/components/ReactDOMShimClient.tsx
@@ -1,0 +1,12 @@
+'use client';
+import * as ReactDOM from 'react-dom';
+import { useEffect } from 'react';
+
+export default function ReactDOMShimClient() {
+  useEffect(() => {
+    const any = ReactDOM as any;
+    if (!any.preload) any.preload = () => {};
+    if (!any.preinit) any.preinit = () => {};
+  }, []);
+  return null;
+}

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -28,7 +28,7 @@ const nextConfig = {
   optimizeFonts: false,
   experimental: {
     instrumentationHook: true,
-    optimizePackageImports: [],
+    optimizePackageImports: [], // 明示的にOFF
   },
   env,
   webpack: (config) => {


### PR DESCRIPTION
## Summary
- add client-side ReactDOM shim and include in layout to disable preload/preinit
- explicitly disable `optimizePackageImports` and keep instrumentation hook
- introduce pages-specific language switcher using `next/router`

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d80956850832398d3c676bcebbf6a