### PR TITLE
Add CI workflow for web app with Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Web CI
+
+on:
+  pull_request:
+    paths:
+      - 'web/**'
+      - '.github/workflows/**'
+
+jobs:
+  web:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for web app using Node 22
- install dependencies, run tests, and attempt build

## Testing
- `npm ci`
- `npm test`
- `npm run build` *(fails: Expected '>', got 'style' in app/api/og/post/[id]/route.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689dffd1c2608323baabdc88d829cad1